### PR TITLE
refactor(shared): centralize identity + explorer helpers

### DIFF
--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -10,6 +10,7 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { truncateIdentity } from '@/lib/utils'
 import { openBrowserVault, setOnboarded } from '@/lib/vault'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -38,11 +39,6 @@ const AppHeader = ({
   const [passphrase, setPassphrase] = useState('')
   const [isLoadingAccounts, setIsLoadingAccounts] = useState(false)
   const [loadError, setLoadError] = useState<string | null>(null)
-  const truncateIdentity = (value: string) => {
-    if (!value) return 'No identity'
-    if (value.length <= 12) return value
-    return `${value.slice(0, 6)}…${value.slice(-6)}`
-  }
 
   const loadAccounts = async () => {
     if (hasLoadedAccounts || isLoadingAccounts) return
@@ -109,7 +105,7 @@ const AppHeader = ({
           <button
             type="button"
             className="flex items-center gap-3 text-left"
-            aria-label="Select account"
+            aria-label={t('home.accounts.selectLabel')}
             onMouseEnter={() => setIsMenuOpen(true)}
           >
             <div className="flex h-10 w-10 items-center justify-center border border-border/60 bg-muted/20">

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -10,7 +10,7 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
-import { truncateIdentity } from '@/lib/utils'
+import { truncateString } from '@/lib/utils'
 import { openBrowserVault, setOnboarded } from '@/lib/vault'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
@@ -113,7 +113,7 @@ const AppHeader = ({
             </div>
             <div className="flex flex-col">
               <span className="text-sm font-semibold text-foreground">{accountName}</span>
-              <span className="text-xs text-muted-foreground">{truncateIdentity(identity)}</span>
+              <span className="text-xs text-muted-foreground">{truncateString(identity)}</span>
             </div>
           </button>
         </PopoverTrigger>
@@ -164,7 +164,7 @@ const AppHeader = ({
                     <div className="flex flex-col">
                       <span className="font-medium text-foreground">{account.name}</span>
                       <span className="text-xs text-muted-foreground">
-                        {truncateIdentity(account.identity)}
+                        {truncateString(account.identity)}
                       </span>
                     </div>
                     {account.identity === identity && (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -62,12 +62,7 @@ type TruncateIdentityOptions = {
 }
 
 export function truncateIdentity(value: string, options: TruncateIdentityOptions = {}) {
-  const {
-    leading = 6,
-    trailing = 6,
-    minLength = 12,
-    emptyLabel = 'No identity',
-  } = options
+  const { leading = 6, trailing = 6, minLength = 12, emptyLabel = 'No identity' } = options
 
   if (!value) return emptyLabel
   if (value.length <= minLength) return value

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -53,3 +53,35 @@ export const formatBalanceCompact = (value: bigint): string => {
     maximumFractionDigits: 2,
   }).format(Number(value))
 }
+
+type TruncateIdentityOptions = {
+  leading?: number
+  trailing?: number
+  minLength?: number
+  emptyLabel?: string
+}
+
+export function truncateIdentity(value: string, options: TruncateIdentityOptions = {}) {
+  const {
+    leading = 6,
+    trailing = 6,
+    minLength = 12,
+    emptyLabel = 'No identity',
+  } = options
+
+  if (!value) return emptyLabel
+  if (value.length <= minLength) return value
+  return `${value.slice(0, leading)}…${value.slice(-trailing)}`
+}
+
+export const EXPLORER_BASE_URL = 'https://explorer.qubic.org'
+
+export type ExplorerObject = 'tx'
+
+export function buildExplorerObjectUrl(object: ExplorerObject, id: string) {
+  const pathMap: Record<ExplorerObject, string> = {
+    tx: 'network/tx',
+  }
+
+  return `${EXPLORER_BASE_URL}/${pathMap[object]}/${id}`
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -54,14 +54,14 @@ export const formatBalanceCompact = (value: bigint): string => {
   }).format(Number(value))
 }
 
-type TruncateIdentityOptions = {
+type TruncateStringOptions = {
   leading?: number
   trailing?: number
   minLength?: number
   emptyLabel?: string
 }
 
-export function truncateIdentity(value: string, options: TruncateIdentityOptions = {}) {
+export function truncateString(value: string, options: TruncateStringOptions = {}) {
   const { leading = 6, trailing = 6, minLength = 12, emptyLabel = 'No identity' } = options
 
   if (!value) return emptyLabel

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -63,6 +63,7 @@
     },
     "accounts": {
       "title": "Accounts",
+      "selectLabel": "Select account",
       "passphrasePlaceholder": "Vault passphrase",
       "passphraseRequired": "Enter your vault passphrase to view accounts.",
       "unlock": "Unlock accounts",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -63,6 +63,7 @@
     },
     "accounts": {
       "title": "Cuentas",
+      "selectLabel": "Seleccionar cuenta",
       "passphrasePlaceholder": "Contrasena del vault",
       "passphraseRequired": "Ingresa la contrasena del vault para ver cuentas.",
       "unlock": "Desbloquear cuentas",

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -1,7 +1,7 @@
 import { useTransactions } from '@qubic-labs/react'
 import { ArrowDownLeftIcon, ArrowUpRightIcon, HashIcon, RefreshCwIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { buildExplorerObjectUrl, truncateIdentity } from '@/lib/utils'
+import { buildExplorerObjectUrl, truncateString } from '@/lib/utils'
 import { useTranslation } from 'react-i18next'
 
 const formatQus = (value: bigint) => {
@@ -81,7 +81,7 @@ const History = () => {
                     <div className="flex flex-col">
                       <span className="text-xs font-semibold text-foreground">{label}</span>
                       <span className="text-xs text-muted-foreground">
-                        {truncateIdentity(counterparty)}
+                        {truncateString(counterparty)}
                       </span>
                     </div>
                   </div>
@@ -104,7 +104,7 @@ const History = () => {
                       target="_blank"
                       rel="noreferrer"
                     >
-                      {truncateIdentity(tx.hash, {
+                      {truncateString(tx.hash, {
                         leading: 6,
                         trailing: 6,
                         minLength: 12,

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -12,11 +12,6 @@ const formatQus = (value: bigint) => {
   return formatter.format(Number(value))
 }
 
-const formatHash = (hash: string) => {
-  if (hash.length <= 12) return hash
-  return `${hash.slice(0, 6)}…${hash.slice(-6)}`
-}
-
 const History = () => {
   const { t } = useTranslation()
   const identity = localStorage.getItem('currentIdentity') ?? '...'
@@ -109,7 +104,12 @@ const History = () => {
                       target="_blank"
                       rel="noreferrer"
                     >
-                      {formatHash(tx.hash)}
+                      {truncateIdentity(tx.hash, {
+                        leading: 6,
+                        trailing: 6,
+                        minLength: 12,
+                        emptyLabel: '',
+                      })}
                     </a>
                   </div>
                   <div className="flex items-center gap-2">

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -1,6 +1,7 @@
 import { useTransactions } from '@qubic-labs/react'
 import { ArrowDownLeftIcon, ArrowUpRightIcon, HashIcon, RefreshCwIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
+import { buildExplorerObjectUrl, truncateIdentity } from '@/lib/utils'
 import { useTranslation } from 'react-i18next'
 
 const formatQus = (value: bigint) => {
@@ -9,11 +10,6 @@ const formatQus = (value: bigint) => {
     maximumFractionDigits: 2,
   })
   return formatter.format(Number(value))
-}
-
-const formatIdentity = (identity: string) => {
-  if (identity.length <= 12) return identity
-  return `${identity.slice(0, 6)}…${identity.slice(-6)}`
 }
 
 const formatHash = (hash: string) => {
@@ -90,7 +86,7 @@ const History = () => {
                     <div className="flex flex-col">
                       <span className="text-xs font-semibold text-foreground">{label}</span>
                       <span className="text-xs text-muted-foreground">
-                        {formatIdentity(counterparty)}
+                        {truncateIdentity(counterparty)}
                       </span>
                     </div>
                   </div>
@@ -108,7 +104,7 @@ const History = () => {
                   <div className="flex items-center gap-2">
                     <HashIcon className="h-3.5 w-3.5" />
                     <a
-                      href={`https://explorer.qubic.org/network/tx/${tx.hash}`}
+                      href={buildExplorerObjectUrl('tx', tx.hash)}
                       className="text-primary hover:underline"
                       target="_blank"
                       rel="noreferrer"

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -13,7 +13,7 @@ import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer'
-import { truncateIdentity } from '@/lib/utils'
+import { truncateString } from '@/lib/utils'
 import { useTranslation } from 'react-i18next'
 import { normalizeBalance, formatBalanceCompact } from '@/lib/utils'
 
@@ -120,7 +120,7 @@ const TransactionsPreview = ({
               <div className="flex flex-col">
                 <span className="text-xs font-semibold text-foreground">{label}</span>
                 <span className="text-xs text-muted-foreground">
-                  {truncateIdentity(counterparty)}
+                  {truncateString(counterparty)}
                 </span>
                 <span className="text-[11px] text-muted-foreground/70">
                   {t('home.recent.tick', { tick: tx.tickNumber })}

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -13,6 +13,7 @@ import { useNavigate } from 'react-router-dom'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer'
+import { truncateIdentity } from '@/lib/utils'
 import { useTranslation } from 'react-i18next'
 import { normalizeBalance, formatBalanceCompact } from '@/lib/utils'
 
@@ -25,11 +26,6 @@ const formatUsd = (value: bigint) => {
     currency: 'USD',
     maximumFractionDigits: 2,
   }).format(usdValue)
-}
-
-const formatIdentity = (identity: string) => {
-  if (identity.length <= 12) return identity
-  return `${identity.slice(0, 6)}…${identity.slice(-6)}`
 }
 
 type LatestStatsResponse = {
@@ -124,7 +120,7 @@ const TransactionsPreview = ({
               <div className="flex flex-col">
                 <span className="text-xs font-semibold text-foreground">{label}</span>
                 <span className="text-xs text-muted-foreground">
-                  {formatIdentity(counterparty)}
+                  {truncateIdentity(counterparty)}
                 </span>
                 <span className="text-[11px] text-muted-foreground/70">
                   {t('home.recent.tick', { tick: tx.tickNumber })}

--- a/src/pages/manage-accounts.tsx
+++ b/src/pages/manage-accounts.tsx
@@ -3,19 +3,13 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { truncateIdentity } from '@/lib/utils'
 import { clearOnboarded, openBrowserVault, setOnboarded } from '@/lib/vault'
 import { useNavigate } from 'react-router-dom'
 
 type AccountEntry = {
   name: string
   identity: string
-}
-
-const truncateIdentity = (identity: string) => {
-  if (identity.length <= 12) {
-    return identity
-  }
-  return `${identity.slice(0, 5)}…${identity.slice(-5)}`
 }
 
 const ManageAccounts = () => {
@@ -111,7 +105,7 @@ const ManageAccounts = () => {
               <div className="text-sm">
                 <p className="font-semibold">{account.name}</p>
                 <p className="text-xs text-muted-foreground">
-                  {truncateIdentity(account.identity)}
+                  {truncateIdentity(account.identity, { leading: 5, trailing: 5 })}
                 </p>
               </div>
               <div className="flex items-center gap-2">

--- a/src/pages/manage-accounts.tsx
+++ b/src/pages/manage-accounts.tsx
@@ -3,7 +3,7 @@ import { Button } from '@/components/ui/button'
 import { Card, CardContent } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { truncateIdentity } from '@/lib/utils'
+import { truncateString } from '@/lib/utils'
 import { clearOnboarded, openBrowserVault, setOnboarded } from '@/lib/vault'
 import { useNavigate } from 'react-router-dom'
 
@@ -105,7 +105,7 @@ const ManageAccounts = () => {
               <div className="text-sm">
                 <p className="font-semibold">{account.name}</p>
                 <p className="text-xs text-muted-foreground">
-                  {truncateIdentity(account.identity, { leading: 5, trailing: 5 })}
+                  {truncateString(account.identity, { leading: 5, trailing: 5 })}
                 </p>
               </div>
               <div className="flex items-center gap-2">


### PR DESCRIPTION
- Added truncateIdentity with options for consistent truncation.
- Added EXPLORER_BASE_URL and buildExplorerObjectUrl('tx', id).
- Added home.accounts.selectLabel in en.json & es.json