### PR TITLE
fix(vault): resolve passphrase validation failure when active account…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Qubic Wallet — a Chrome Extension (Manifest V3) built with React 19, TypeScript 5.9, and Vite 7. The wallet manages Qubic cryptocurrency accounts, balances, transfers, and assets via the Qubic RPC API.
+
+## Commands
+
+```bash
+# Development — requires Node 20.19+ (use `nvm use 20` if needed)
+bun dev                    # Vite dev server (serves index.html at localhost:5173)
+bun run dev:extension      # Watch-mode build to dist-dev/ with reload stamp
+bun run build              # Production build: tsc -b && vite build → dist/
+
+# Linting & formatting (Biome)
+bun run lint               # Check with Biome
+bun run format             # Auto-fix with Biome --write
+
+# Type checking only
+bunx tsc -b
+```
+
+**Package manager:** Bun (primary), npm also works with `--legacy-peer-deps` for React 19 peer conflicts.
+
+## Extension Entry Points
+
+Vite builds 4 HTML entry points (configured in `vite.config.ts`):
+
+| File | Purpose | Dimensions |
+|------|---------|------------|
+| `popup.html` | Extension popup (default action) | 360×600px fixed |
+| `sidepanel.html` | Chrome side panel | Full height |
+| `tab.html` | Full browser tab | Full viewport |
+| `index.html` | Dev/standalone | Full viewport |
+
+To test as a Chrome extension: build, then load `dist/` as unpacked extension at `chrome://extensions`.
+
+Build mode `--mode extension` outputs to `dist-dev/` and emits `reload.json` for live reload during development.
+
+## Architecture
+
+### Routing (`src/router/app-router.tsx`)
+
+Three-state router: **not onboarded** → **locked** → **authenticated**.
+
+- Not onboarded: shows Welcome + onboarding flows (`/onboarding/*`)
+- Locked: redirects all routes to `/unlock`
+- Authenticated: full app with nav bar
+
+Lock state is driven by `src/lib/lock.ts` (localStorage-based, 1–120 min timeout, default 10 min). Cross-tab sync via `StorageEvent` and custom `wallet-lock-updated` event.
+
+### Provider Stack (`src/app/app.tsx`)
+
+`ThemeProvider` → `SdkProvider` (RPC: `https://rpc.qubic.org`) → `QubicQueryProvider` (TanStack Query) → `HashRouter` → `AppRouter` → `Toaster` (Sonner)
+
+### Core Libraries (`src/lib/`)
+
+- **vault.ts** — Opens/validates encrypted seed vault via `@qubic-labs/sdk`. All seed operations require passphrase.
+- **accounts.ts** — localStorage-backed account cache, ordering, and watch-only accounts. Emits `wallet-account-updated` custom event.
+- **lock.ts** — Lock/unlock state, timeout scheduling. Emits `wallet-lock-updated` custom event.
+- **assets.ts** — Fetches owned assets from RPC, aggregates duplicates. Exports `useOwnedAssets` React Query hook.
+- **vault-export.ts** — Exports vault to `.qubic-vault` format (RSA-OAEP + AES-GCM + PBKDF2).
+- **pending-transactions.ts** — Pending TX state using `useSyncExternalStore`. Persists to localStorage.
+- **qx.ts** — QX asset transfer payload builder (80-byte binary layout).
+- **utils.ts** — `truncateString`, `formatBalance`, `formatBalanceCompact`, `isValidIdentity`, `buildExplorerObjectUrl`, `cn` (clsx + tailwind-merge).
+
+### Custom Events
+
+Components communicate via `window.dispatchEvent`:
+- `wallet-lock-updated` — lock state changed
+- `wallet-account-updated` — account added/removed/renamed/reordered
+- `wallet-pending-settled` — pending TX confirmed (dispatched with 2.5s delay)
+
+### Styling
+
+Tailwind CSS 4 with CSS custom properties for theming. Dark theme by default (`next-themes`). Global styles in `src/styles/global.css`. Primary color: `#1adef5` (cyan).
+
+Components in `src/components/ui/` are Radix UI primitives — Biome linting is disabled for that directory.
+
+### i18n
+
+English (`en`) and Spanish (`es`) via `i18next`. Locale files at `src/locales/{en,es}.json`. Language persisted to `localStorage.language`.
+
+## Code Quality
+
+- **No code duplication.** Extract shared logic into `src/lib/` utilities. Reviewers are strict about this.
+- **Avoid using `localStorage.getItem('currentIdentity')` to look up vault entries.** The active account may be watch-only and absent from the encrypted vault. Use `vault.list()[0]?.identity` instead.
+
+## CI
+
+GitHub Actions (`.github/workflows/ci.yml`): lint → typecheck → build. Uses Bun 1.3.8.

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -8,7 +8,12 @@ import { useTranslation } from 'react-i18next'
 import { useQueries } from '@tanstack/react-query'
 import { useSdk } from '@qubic-labs/react'
 import { formatBalanceCompact } from '@/lib/utils'
-import { getAccountOrder, getCachedAccounts, getWatchOnlyAccounts } from '@/lib/accounts'
+import {
+  getAccountOrder,
+  getCachedAccounts,
+  getCurrentIdentity,
+  getWatchOnlyAccounts,
+} from '@/lib/accounts'
 import { useNavigate } from 'react-router-dom'
 import { useCallback } from 'react'
 
@@ -31,13 +36,13 @@ const AppHeader = ({
   const [accountName, setAccountName] = useState(
     localStorage.getItem('currentAccountName') ?? 'Main account',
   )
-  const [identity, setIdentity] = useState(localStorage.getItem('currentIdentity') ?? '')
+  const [identity, setIdentity] = useState(getCurrentIdentity())
   const [accounts, setAccounts] = useState<Array<{ name: string; identity: string }>>([])
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   const refreshAccounts = useCallback(() => {
     const nextAccountName = localStorage.getItem('currentAccountName') ?? 'Main account'
-    const nextIdentity = localStorage.getItem('currentIdentity') ?? ''
+    const nextIdentity = getCurrentIdentity()
     setAccountName(nextAccountName)
     setIdentity(nextIdentity)
 

--- a/src/components/onboarding/passphrase-step.tsx
+++ b/src/components/onboarding/passphrase-step.tsx
@@ -1,5 +1,13 @@
-import { Input } from '@/components/ui/input'
+import { useState } from 'react'
+import { EyeIcon, EyeOffIcon } from 'lucide-react'
 import { Label } from '@/components/ui/label'
+import { Input } from '@/components/ui/input'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/input-group'
 
 type PassphraseStepProps = {
   variant: 'onboarding' | 'add-address'
@@ -20,6 +28,9 @@ const PassphraseStep = ({
   onPassphraseChange,
   onConfirmPassphraseChange,
 }: PassphraseStepProps) => {
+  const [showPassphrase, setShowPassphrase] = useState(false)
+  const [showConfirm, setShowConfirm] = useState(false)
+
   return (
     <div className="space-y-4">
       <div className="space-y-1">
@@ -44,25 +55,49 @@ const PassphraseStep = ({
         <Label htmlFor="passphrase">
           {variant === 'add-address' ? 'Current vault passphrase' : 'Vault passphrase'}
         </Label>
-        <Input
-          id="passphrase"
-          type="password"
-          value={passphrase}
-          onChange={(event) => onPassphraseChange(event.target.value)}
-        />
+        <InputGroup>
+          <InputGroupInput
+            id="passphrase"
+            type={showPassphrase ? 'text' : 'password'}
+            value={passphrase}
+            onChange={(event) => onPassphraseChange(event.target.value)}
+          />
+          <InputGroupAddon align="inline-end">
+            <InputGroupButton
+              size="icon-xs"
+              aria-label={showPassphrase ? 'Hide passphrase' : 'Show passphrase'}
+              onClick={() => setShowPassphrase((prev) => !prev)}
+            >
+              {showPassphrase ? <EyeOffIcon className="size-4" /> : <EyeIcon className="size-4" />}
+            </InputGroupButton>
+          </InputGroupAddon>
+        </InputGroup>
         {variant !== 'add-address' && (
           <p className="text-xs text-muted-foreground">Minimum 12 characters.</p>
         )}
       </div>
-      <div className="space-y-2">
-        <Label htmlFor="confirm-passphrase">Re-enter vault passphrase</Label>
-        <Input
-          id="confirm-passphrase"
-          type="password"
-          value={confirmPassphrase}
-          onChange={(event) => onConfirmPassphraseChange(event.target.value)}
-        />
-      </div>
+      {variant !== 'add-address' && (
+        <div className="space-y-2">
+          <Label htmlFor="confirm-passphrase">Re-enter vault passphrase</Label>
+          <InputGroup>
+            <InputGroupInput
+              id="confirm-passphrase"
+              type={showConfirm ? 'text' : 'password'}
+              value={confirmPassphrase}
+              onChange={(event) => onConfirmPassphraseChange(event.target.value)}
+            />
+            <InputGroupAddon align="inline-end">
+              <InputGroupButton
+                size="icon-xs"
+                aria-label={showConfirm ? 'Hide passphrase' : 'Show passphrase'}
+                onClick={() => setShowConfirm((prev) => !prev)}
+              >
+                {showConfirm ? <EyeOffIcon className="size-4" /> : <EyeIcon className="size-4" />}
+              </InputGroupButton>
+            </InputGroupAddon>
+          </InputGroup>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -12,7 +12,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
       data-slot="input-group"
       role="group"
       className={cn(
-        'group/input-group border-input dark:bg-input/30 relative flex w-full items-center rounded-md border shadow-xs transition-[color,box-shadow] outline-none',
+        'group/input-group border-input bg-muted/30 relative flex w-full items-center rounded-md border shadow-xs transition-[color,box-shadow] outline-none',
         'h-9 min-w-0 has-[>textarea]:h-auto',
 
         // Variants based on alignment.

--- a/src/lib/accounts.ts
+++ b/src/lib/accounts.ts
@@ -89,3 +89,18 @@ export const saveAccountOrder = (identities: string[]) => {
     // Ignore storage failures.
   }
 }
+
+export const getCurrentIdentity = (): string => localStorage.getItem('currentIdentity') ?? ''
+
+export const isWatchOnlyIdentity = (identity: string): boolean =>
+  getWatchOnlyAccounts().some((entry) => entry.identity === identity)
+
+/**
+ * Return the current identity only if it belongs to the encrypted vault
+ * (i.e. it is not watch-only). Falls back to the first cached vault account.
+ */
+export const getCurrentVaultIdentity = (): string => {
+  const stored = getCurrentIdentity()
+  if (stored && !isWatchOnlyIdentity(stored)) return stored
+  return getCachedAccounts()[0]?.identity ?? ''
+}

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1,16 +1,39 @@
 import {
+  type SeedVault,
   createLocalStorageVaultStore,
   openSeedVaultBrowser,
   VaultEntryNotFoundError,
   VaultInvalidPassphraseError,
 } from '@qubic-labs/sdk'
-import { emitAccountUpdated, getCachedAccounts } from '@/lib/accounts'
+import { emitAccountUpdated } from '@/lib/accounts'
 
 const VAULT_STORAGE_KEY = 'qubic.vault'
 
 export const openBrowserVault = async (passphrase: string, create = false) => {
   const store = createLocalStorageVaultStore(VAULT_STORAGE_KEY)
   return openSeedVaultBrowser({ store, passphrase, create })
+}
+
+/**
+ * Verify that a vault was opened with the correct passphrase by reading the
+ * first entry's seed. Uses `vault.list()` so it works regardless of whether
+ * the currently-selected account is watch-only.
+ */
+export const verifyVaultAccess = async (
+  vault: SeedVault,
+): Promise<{ valid: true } | { valid: false; reason: 'invalid' | 'error' }> => {
+  try {
+    const expectedIdentity = vault.list()[0]?.identity
+    if (expectedIdentity) {
+      await vault.getSeed(expectedIdentity)
+    }
+    return { valid: true }
+  } catch (error) {
+    if (error instanceof VaultInvalidPassphraseError || error instanceof VaultEntryNotFoundError) {
+      return { valid: false, reason: 'invalid' }
+    }
+    return { valid: false, reason: 'error' }
+  }
 }
 
 /**
@@ -22,13 +45,7 @@ export const validateVaultPassphrase = async (
 ): Promise<{ valid: true } | { valid: false; reason: 'invalid' | 'error' }> => {
   try {
     const vault = await openBrowserVault(passphrase, false)
-    const cached = getCachedAccounts()
-    const currentIdentity = localStorage.getItem('currentIdentity')
-    const expectedIdentity = currentIdentity ?? cached[0]?.identity
-    if (expectedIdentity) {
-      await vault.getSeed(expectedIdentity)
-    }
-    return { valid: true }
+    return verifyVaultAccess(vault)
   } catch (error) {
     if (error instanceof VaultInvalidPassphraseError || error instanceof VaultEntryNotFoundError) {
       return { valid: false, reason: 'invalid' }

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -20,6 +20,7 @@ import {
   resolvePendingTransactions,
   usePendingTransactionsVersion,
 } from '@/lib/pending-transactions'
+import { getCurrentIdentity } from '@/lib/accounts'
 
 const formatQus = (value: bigint) => {
   const formatter = new Intl.NumberFormat('en', {
@@ -47,7 +48,7 @@ const History = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   usePendingTransactionsVersion()
-  const [identity, setIdentity] = useState(localStorage.getItem('currentIdentity') ?? '')
+  const [identity, setIdentity] = useState(getCurrentIdentity())
   const transactions = useTransactions(
     {
       identity,
@@ -66,7 +67,7 @@ const History = () => {
 
   useEffect(() => {
     const refreshIdentity = () => {
-      setIdentity(localStorage.getItem('currentIdentity') ?? '')
+      setIdentity(getCurrentIdentity())
     }
 
     refreshIdentity()

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -20,7 +20,7 @@ import { Button } from '@/components/ui/button'
 import { Drawer, DrawerContent, DrawerHeader, DrawerTitle } from '@/components/ui/drawer'
 import { useTranslation } from 'react-i18next'
 import { normalizeBalance, formatBalanceCompact, truncateString } from '@/lib/utils'
-import { getWatchOnlyAccounts } from '@/lib/accounts'
+import { getCurrentIdentity, isWatchOnlyIdentity } from '@/lib/accounts'
 import { aggregateAssets, formatAssetUnits, useOwnedAssets } from '@/lib/assets'
 import {
   getPendingOutgoingDebit,
@@ -334,12 +334,8 @@ const TransactionsPreview = ({
 const Home = () => {
   const { t } = useTranslation()
   usePendingTransactionsVersion()
-  const [identity, setIdentity] = useState(localStorage.getItem('currentIdentity') ?? '')
-  const [isWatchOnly, setIsWatchOnly] = useState(() =>
-    getWatchOnlyAccounts().some(
-      (entry) => entry.identity === (localStorage.getItem('currentIdentity') ?? ''),
-    ),
-  )
+  const [identity, setIdentity] = useState(getCurrentIdentity())
+  const [isWatchOnly, setIsWatchOnly] = useState(() => isWatchOnlyIdentity(getCurrentIdentity()))
   const pathname = globalThis.location?.pathname ?? ''
   const isSidePanel = pathname.endsWith('sidepanel.html')
   const isPopup = pathname.endsWith('popup.html')
@@ -410,9 +406,9 @@ const Home = () => {
 
   useEffect(() => {
     const refreshIdentity = () => {
-      const nextIdentity = localStorage.getItem('currentIdentity') ?? ''
+      const nextIdentity = getCurrentIdentity()
       setIdentity(nextIdentity)
-      setIsWatchOnly(getWatchOnlyAccounts().some((entry) => entry.identity === nextIdentity))
+      setIsWatchOnly(isWatchOnlyIdentity(nextIdentity))
     }
 
     refreshIdentity()

--- a/src/pages/manage-accounts.tsx
+++ b/src/pages/manage-accounts.tsx
@@ -42,6 +42,7 @@ import { Textarea } from '@/components/ui/textarea'
 import {
   getAccountOrder,
   getCachedAccounts,
+  getCurrentIdentity,
   getWatchOnlyAccounts,
   saveAccountOrder,
   saveCachedAccounts,
@@ -74,9 +75,7 @@ const ManageAccounts = () => {
   })
   const [status, setStatus] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
-  const [currentIdentity, setCurrentIdentity] = useState(
-    localStorage.getItem('currentIdentity') ?? '',
-  )
+  const [currentIdentity, setCurrentIdentity] = useState(getCurrentIdentity())
   const [draggedId, setDraggedId] = useState<string | null>(null)
   const [dragOverId, setDragOverId] = useState<string | null>(null)
   const [renameTarget, setRenameTarget] = useState<AccountEntry | null>(null)
@@ -125,7 +124,7 @@ const ManageAccounts = () => {
 
   useEffect(() => {
     const refreshCurrentIdentity = () => {
-      setCurrentIdentity(localStorage.getItem('currentIdentity') ?? '')
+      setCurrentIdentity(getCurrentIdentity())
     }
     window.addEventListener('storage', refreshCurrentIdentity)
     window.addEventListener('wallet-account-updated', refreshCurrentIdentity)

--- a/src/pages/onboarding/create-wallet.tsx
+++ b/src/pages/onboarding/create-wallet.tsx
@@ -5,9 +5,13 @@ import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Progress } from '@/components/ui/progress'
 import { generateSeed, isSeedLike } from '@/lib/seed'
-import { VaultEntryNotFoundError, VaultInvalidPassphraseError } from '@qubic-labs/sdk'
 import { setUnlocked } from '@/lib/lock'
-import { openBrowserVault, setOnboarded } from '@/lib/vault'
+import {
+  openBrowserVault,
+  setOnboarded,
+  validateVaultPassphrase,
+  verifyVaultAccess,
+} from '@/lib/vault'
 import { getCachedAccounts, getWatchOnlyAccounts, saveCachedAccounts } from '@/lib/accounts'
 import SeedSecurityStep from '@/components/onboarding/seed-security-step'
 import PassphraseStep from '@/components/onboarding/passphrase-step'
@@ -112,15 +116,15 @@ const CreateWallet = ({
       setStatus('Passphrase is required.')
       return
     }
-    if (step === 2 && !confirmPassphrase.trim()) {
-      setStatus('Please re-enter your passphrase.')
-      return
-    }
-    if (step === 2 && passphrase !== confirmPassphrase) {
-      setStatus('Passphrases do not match.')
-      return
-    }
     if (step === 2 && variant !== 'add-address') {
+      if (!confirmPassphrase.trim()) {
+        setStatus('Please re-enter your passphrase.')
+        return
+      }
+      if (passphrase !== confirmPassphrase) {
+        setStatus('Passphrases do not match.')
+        return
+      }
       if (passphrase.length < 12) {
         setStatus('Passphrase must be at least 12 characters.')
         return
@@ -135,23 +139,13 @@ const CreateWallet = ({
         setStatus('Wallet name already exists.')
         return
       }
-      try {
-        const vault = await openBrowserVault(passphrase.trim(), false)
-        const cached = getCachedAccounts()
-        const currentIdentity = localStorage.getItem('currentIdentity')
-        const expectedIdentity = currentIdentity ?? cached[0]?.identity
-        if (expectedIdentity) {
-          await vault.getSeed(expectedIdentity)
-        }
-      } catch (error) {
-        if (
-          error instanceof VaultInvalidPassphraseError ||
-          error instanceof VaultEntryNotFoundError
-        ) {
-          setStatus('Invalid vault passphrase.')
-          return
-        }
-        setStatus('Failed to validate vault passphrase.')
+      const result = await validateVaultPassphrase(passphrase.trim())
+      if (!result.valid) {
+        setStatus(
+          result.reason === 'invalid'
+            ? 'Invalid vault passphrase.'
+            : 'Failed to validate vault passphrase.',
+        )
         return
       }
     }
@@ -183,17 +177,17 @@ const CreateWallet = ({
       setStep(2)
       return
     }
-    if (!confirmPassphrase.trim()) {
-      setStatus('Please re-enter your passphrase.')
-      setStep(2)
-      return
-    }
-    if (passphrase !== confirmPassphrase) {
-      setStatus('Passphrases do not match.')
-      setStep(2)
-      return
-    }
     if (variant !== 'add-address') {
+      if (!confirmPassphrase.trim()) {
+        setStatus('Please re-enter your passphrase.')
+        setStep(2)
+        return
+      }
+      if (passphrase !== confirmPassphrase) {
+        setStatus('Passphrases do not match.')
+        setStep(2)
+        return
+      }
       if (passphrase.length < 12) {
         setStatus('Passphrase must be at least 12 characters.')
         setStep(2)
@@ -221,23 +215,11 @@ const CreateWallet = ({
       setIsSaving(true)
       const vault = await openBrowserVault(passphrase, variant !== 'add-address')
       if (variant === 'add-address') {
-        const cached = getCachedAccounts()
-        const currentIdentity = localStorage.getItem('currentIdentity')
-        const expectedIdentity = currentIdentity ?? cached[0]?.identity
-        if (expectedIdentity) {
-          try {
-            await vault.getSeed(expectedIdentity)
-          } catch (error) {
-            if (
-              error instanceof VaultInvalidPassphraseError ||
-              error instanceof VaultEntryNotFoundError
-            ) {
-              setStatus('Invalid vault passphrase.')
-              setIsSaving(false)
-              return
-            }
-            throw error
-          }
+        const check = await verifyVaultAccess(vault)
+        if (!check.valid) {
+          setStatus('Invalid vault passphrase.')
+          setIsSaving(false)
+          return
         }
       }
       const entry = await vault.addSeed({ name, seed, overwrite: true })

--- a/src/pages/onboarding/import-seed.tsx
+++ b/src/pages/onboarding/import-seed.tsx
@@ -1,17 +1,27 @@
 import { useMemo, useState } from 'react'
 import { identityFromSeed } from '@qubic-labs/core'
-import { ArrowLeftIcon, ArrowRightIcon, KeyRoundIcon } from 'lucide-react'
+import { ArrowLeftIcon, ArrowRightIcon, EyeIcon, EyeOffIcon, KeyRoundIcon } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Progress } from '@/components/ui/progress'
 import { Textarea } from '@/components/ui/textarea'
-import { VaultEntryNotFoundError, VaultInvalidPassphraseError } from '@qubic-labs/sdk'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/input-group'
 import { isSeedLike } from '@/lib/seed'
 import { getCachedAccounts, getWatchOnlyAccounts, saveCachedAccounts } from '@/lib/accounts'
 import { setUnlocked } from '@/lib/lock'
-import { openBrowserVault, setOnboarded } from '@/lib/vault'
+import {
+  openBrowserVault,
+  setOnboarded,
+  validateVaultPassphrase,
+  verifyVaultAccess,
+} from '@/lib/vault'
 
 const TOTAL_STEPS = 3
 const SEED_LENGTH = 55
@@ -41,6 +51,7 @@ const ImportSeed = ({
   const [status, setStatus] = useState<string | null>(null)
   const [isSaving, setIsSaving] = useState(false)
   const [derivedIdentity, setDerivedIdentity] = useState<string | null>(null)
+  const [showPassphrase, setShowPassphrase] = useState(false)
 
   const progressValue = useMemo(() => (step / TOTAL_STEPS) * 100, [step])
   const seedLength = seed.length
@@ -98,23 +109,13 @@ const ImportSeed = ({
         setStatus('Wallet name already exists.')
         return
       }
-      try {
-        const vault = await openBrowserVault(passphrase.trim(), false)
-        const cached = getCachedAccounts()
-        const currentIdentity = localStorage.getItem('currentIdentity')
-        const expectedIdentity = currentIdentity ?? cached[0]?.identity
-        if (expectedIdentity) {
-          await vault.getSeed(expectedIdentity)
-        }
-      } catch (error) {
-        if (
-          error instanceof VaultInvalidPassphraseError ||
-          error instanceof VaultEntryNotFoundError
-        ) {
-          setStatus('Invalid vault passphrase.')
-          return
-        }
-        setStatus('Failed to validate vault passphrase.')
+      const result = await validateVaultPassphrase(passphrase.trim())
+      if (!result.valid) {
+        setStatus(
+          result.reason === 'invalid'
+            ? 'Invalid vault passphrase.'
+            : 'Failed to validate vault passphrase.',
+        )
         return
       }
     }
@@ -162,23 +163,11 @@ const ImportSeed = ({
       setIsSaving(true)
       const vault = await openBrowserVault(passphrase, variant !== 'add-address')
       if (variant === 'add-address') {
-        const cached = getCachedAccounts()
-        const currentIdentity = localStorage.getItem('currentIdentity')
-        const expectedIdentity = currentIdentity ?? cached[0]?.identity
-        if (expectedIdentity) {
-          try {
-            await vault.getSeed(expectedIdentity)
-          } catch (error) {
-            if (
-              error instanceof VaultInvalidPassphraseError ||
-              error instanceof VaultEntryNotFoundError
-            ) {
-              setStatus('Invalid vault passphrase.')
-              setIsSaving(false)
-              return
-            }
-            throw error
-          }
+        const check = await verifyVaultAccess(vault)
+        if (!check.valid) {
+          setStatus('Invalid vault passphrase.')
+          setIsSaving(false)
+          return
         }
       }
       if (variant === 'add-address') {
@@ -273,12 +262,27 @@ const ImportSeed = ({
                 <Label htmlFor="passphrase">
                   {variant === 'add-address' ? 'Current vault passphrase' : 'Vault passphrase'}
                 </Label>
-                <Input
-                  id="passphrase"
-                  type="password"
-                  value={passphrase}
-                  onChange={(event) => setPassphrase(event.target.value)}
-                />
+                <InputGroup>
+                  <InputGroupInput
+                    id="passphrase"
+                    type={showPassphrase ? 'text' : 'password'}
+                    value={passphrase}
+                    onChange={(event) => setPassphrase(event.target.value)}
+                  />
+                  <InputGroupAddon align="inline-end">
+                    <InputGroupButton
+                      size="icon-xs"
+                      aria-label={showPassphrase ? 'Hide passphrase' : 'Show passphrase'}
+                      onClick={() => setShowPassphrase((prev) => !prev)}
+                    >
+                      {showPassphrase ? (
+                        <EyeOffIcon className="size-4" />
+                      ) : (
+                        <EyeIcon className="size-4" />
+                      )}
+                    </InputGroupButton>
+                  </InputGroupAddon>
+                </InputGroup>
               </div>
             </div>
           )}

--- a/src/pages/onboarding/import-vault.tsx
+++ b/src/pages/onboarding/import-vault.tsx
@@ -1,9 +1,22 @@
 import { useMemo, useState } from 'react'
-import { ArrowLeftIcon, ArrowRightIcon, FileJsonIcon, UploadCloudIcon } from 'lucide-react'
+import {
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  EyeIcon,
+  EyeOffIcon,
+  FileJsonIcon,
+  UploadCloudIcon,
+} from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+} from '@/components/ui/input-group'
 import { Label } from '@/components/ui/label'
 import { Progress } from '@/components/ui/progress'
 import { setUnlocked } from '@/lib/lock'
@@ -24,6 +37,8 @@ const ImportVault = () => {
   const [status, setStatus] = useState<string | null>(null)
   const [isSaving, setIsSaving] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
+  const [showPassphrase, setShowPassphrase] = useState(false)
+  const [showSourcePassphrase, setShowSourcePassphrase] = useState(false)
 
   const progressValue = useMemo(() => (step / TOTAL_STEPS) * 100, [step])
 
@@ -256,23 +271,53 @@ const ImportVault = () => {
                 <Label htmlFor="passphrase">
                   {t('onboarding.importVault.unlockSecure.newPassphrase')}
                 </Label>
-                <Input
-                  id="passphrase"
-                  type="password"
-                  value={passphrase}
-                  onChange={(event) => setPassphrase(event.target.value)}
-                />
+                <InputGroup>
+                  <InputGroupInput
+                    id="passphrase"
+                    type={showPassphrase ? 'text' : 'password'}
+                    value={passphrase}
+                    onChange={(event) => setPassphrase(event.target.value)}
+                  />
+                  <InputGroupAddon align="inline-end">
+                    <InputGroupButton
+                      type="button"
+                      variant="ghost"
+                      onClick={() => setShowPassphrase((v) => !v)}
+                    >
+                      {showPassphrase ? (
+                        <EyeOffIcon className="size-4" />
+                      ) : (
+                        <EyeIcon className="size-4" />
+                      )}
+                    </InputGroupButton>
+                  </InputGroupAddon>
+                </InputGroup>
               </div>
               <div className="space-y-2">
                 <Label htmlFor="source-passphrase">
                   {t('onboarding.importVault.unlockSecure.sourcePassphrase')}
                 </Label>
-                <Input
-                  id="source-passphrase"
-                  type="password"
-                  value={sourcePassphrase}
-                  onChange={(event) => setSourcePassphrase(event.target.value)}
-                />
+                <InputGroup>
+                  <InputGroupInput
+                    id="source-passphrase"
+                    type={showSourcePassphrase ? 'text' : 'password'}
+                    value={sourcePassphrase}
+                    onChange={(event) => setSourcePassphrase(event.target.value)}
+                  />
+                  <InputGroupAddon align="inline-end">
+                    <InputGroupButton
+                      type="button"
+                      variant="ghost"
+                      onClick={() => setShowSourcePassphrase((v) => !v)}
+                    >
+                      {showSourcePassphrase ? (
+                        <EyeOffIcon className="size-4" />
+                      ) : (
+                        <EyeIcon className="size-4" />
+                      )}
+                    </InputGroupButton>
+                  </InputGroupAddon>
+                </InputGroup>
               </div>
             </div>
           )}

--- a/src/pages/passphrase-auth.tsx
+++ b/src/pages/passphrase-auth.tsx
@@ -19,11 +19,12 @@ import {
 } from '@/components/ui/input-group'
 import { getCurrentVaultIdentity } from '@/lib/accounts'
 import { setUnlocked } from '@/lib/lock'
-import { openBrowserVault } from '@/lib/vault'
+import { openBrowserVault, verifyVaultAccess } from '@/lib/vault'
 import { truncateString } from '@/lib/utils'
 
 type PassphraseAuthProps = {
   open?: boolean
+  identity?: string
   title?: string
   subtitle?: string
   onSuccess: (seed: string) => void
@@ -32,13 +33,14 @@ type PassphraseAuthProps = {
 
 const PassphraseAuth = ({
   open = true,
+  identity,
   title,
   subtitle,
   onSuccess,
   onCancel,
 }: PassphraseAuthProps) => {
   const { t } = useTranslation()
-  const currentIdentity = getCurrentVaultIdentity()
+  const currentIdentity = identity ?? getCurrentVaultIdentity()
 
   const [passphrase, setPassphrase] = useState('')
   const [error, setError] = useState('')
@@ -56,7 +58,22 @@ const PassphraseAuth = ({
 
     try {
       const vault = await openBrowserVault(passphrase, false)
-      const seed = await vault.getSeed(currentIdentity)
+      const access = await verifyVaultAccess(vault)
+      if (!access.valid) {
+        setError(
+          access.reason === 'invalid'
+            ? t('passphraseAuth.errors.invalidPassphrase')
+            : t('passphraseAuth.errors.generic'),
+        )
+        return
+      }
+
+      const seedIdentity = identity ?? vault.list()[0]?.identity
+      if (!seedIdentity) {
+        setError(t('passphraseAuth.errors.accountNotFound'))
+        return
+      }
+      const seed = await vault.getSeed(seedIdentity)
 
       setUnlocked()
       setPassphrase('')

--- a/src/pages/passphrase-auth.tsx
+++ b/src/pages/passphrase-auth.tsx
@@ -17,7 +17,7 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from '@/components/ui/input-group'
-import { getCachedAccounts } from '@/lib/accounts'
+import { getCurrentVaultIdentity } from '@/lib/accounts'
 import { setUnlocked } from '@/lib/lock'
 import { openBrowserVault } from '@/lib/vault'
 import { truncateString } from '@/lib/utils'
@@ -38,8 +38,7 @@ const PassphraseAuth = ({
   onCancel,
 }: PassphraseAuthProps) => {
   const { t } = useTranslation()
-  const storedIdentity = localStorage.getItem('currentIdentity')
-  const currentIdentity = storedIdentity ?? getCachedAccounts()[0]?.identity ?? ''
+  const currentIdentity = getCurrentVaultIdentity()
 
   const [passphrase, setPassphrase] = useState('')
   const [error, setError] = useState('')

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -39,7 +39,12 @@ import {
   truncateString,
 } from '@/lib/utils'
 import PassphraseAuth from '@/pages/passphrase-auth'
-import { getCachedAccounts, getWatchOnlyAccounts } from '@/lib/accounts'
+import {
+  getCachedAccounts,
+  getCurrentIdentity,
+  getWatchOnlyAccounts,
+  isWatchOnlyIdentity,
+} from '@/lib/accounts'
 import {
   type AggregatedAsset,
   aggregateAssets,
@@ -714,14 +719,8 @@ const Transfer = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   usePendingTransactionsVersion()
-  const [currentIdentity, setCurrentIdentity] = useState(
-    localStorage.getItem('currentIdentity') ?? '',
-  )
-  const [isWatchOnly, setIsWatchOnly] = useState(() =>
-    getWatchOnlyAccounts().some(
-      (entry) => entry.identity === (localStorage.getItem('currentIdentity') ?? ''),
-    ),
-  )
+  const [currentIdentity, setCurrentIdentity] = useState(getCurrentIdentity())
+  const [isWatchOnly, setIsWatchOnly] = useState(() => isWatchOnlyIdentity(getCurrentIdentity()))
   const [fromAccounts, setFromAccounts] = useState<SourceAccount[]>(() => getSourceAccounts())
   const [vaultRecipients, setVaultRecipients] = useState(() => getCachedAccounts())
 
@@ -805,13 +804,11 @@ const Transfer = () => {
 
   useEffect(() => {
     const refreshAccount = () => {
-      const nextIdentity = localStorage.getItem('currentIdentity') ?? ''
+      const nextIdentity = getCurrentIdentity()
       const nextAccounts = getSourceAccounts()
       setCurrentIdentity(nextIdentity)
       setFromAccounts(nextAccounts)
-      setIsWatchOnly(
-        nextAccounts.some((entry) => entry.identity === nextIdentity && entry.watchOnly),
-      )
+      setIsWatchOnly(isWatchOnlyIdentity(nextIdentity))
       setVaultRecipients(getCachedAccounts())
     }
 

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -1174,6 +1174,7 @@ const Transfer = () => {
       {step === 'auth' && (
         <PassphraseAuth
           open={step === 'auth'}
+          identity={currentIdentity}
           onSuccess={handleAuthSuccess}
           onCancel={handleAuthCancel}
         />

--- a/src/router/app-router.tsx
+++ b/src/router/app-router.tsx
@@ -23,11 +23,12 @@ import {
   isWalletLocked,
   lockWallet,
 } from '../lib/lock'
+import { getCurrentIdentity } from '../lib/accounts'
 
 const hasAccounts = () => {
   try {
     const hasAccount = localStorage.getItem('hasAccount') === 'true'
-    const identity = localStorage.getItem('currentIdentity')
+    const identity = getCurrentIdentity()
     return hasAccount && Boolean(identity)
   } catch {
     return false


### PR DESCRIPTION
… is watch-only

Replace currentIdentity lookup with vault.list()[0] via shared helpers. Hide confirm field and add eye toggle for add-address variant.