### PR TITLE
Settings UI improvements: General sub-page, destructive button variant, and Spanish locale fixes

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -12,6 +12,8 @@ const buttonVariants = cva(
         default: 'bg-primary text-primary-foreground hover:bg-primary/90',
         destructive:
           'bg-destructive text-white hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
+        'destructive-outline':
+          'h-[52px] rounded-xl border border-destructive text-destructive hover:bg-destructive/10 dark:border-[#381D1E]',
         outline:
           'border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 dark:hover:text-primary',
         secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -111,6 +111,8 @@
       }
     },
     "categories": {
+      "general": "General",
+      "generalDesc": "Language and theme preferences",
       "security": "Security",
       "securityDesc": "Password, auto-lock, and app reset",
       "backup": "Backup",
@@ -121,6 +123,10 @@
       "supportDesc": "Get help and report issues",
       "about": "About",
       "aboutDesc": "App version and info"
+    },
+    "general": {
+      "title": "General",
+      "back": "Settings"
     },
     "security": {
       "title": "Security",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -76,11 +76,11 @@
     "accounts": {
       "title": "Cuentas",
       "selectLabel": "Seleccionar cuenta",
-      "passphrasePlaceholder": "Contrasena del vault",
-      "passphraseRequired": "Ingresa la contrasena del vault para ver cuentas.",
+      "passphrasePlaceholder": "Contraseña del vault",
+      "passphraseRequired": "Ingresa la contraseña del vault para ver cuentas.",
       "unlock": "Desbloquear cuentas",
       "unlocking": "Desbloqueando...",
-      "unlockFailed": "No se pudo desbloquear el vault. Verifica la contrasena.",
+      "unlockFailed": "No se pudo desbloquear el vault. Verifica la contraseña.",
       "empty": "No hay cuentas adicionales.",
       "create": "Crear una nueva cuenta"
     }
@@ -101,18 +101,20 @@
       "button": "Exportar vault",
       "drawerTitle": "Exportar archivo vault",
       "drawerDescription": "Descarga tu vault en un formato compatible con la billetera web de Qubic.",
-      "passphrase": "Contrasena del vault",
+      "passphrase": "Contraseña del vault",
       "confirm": "Exportar vault",
       "exporting": "Exportando...",
       "errors": {
-        "passphraseRequired": "Se requiere contrasena.",
-        "invalidPassphrase": "Contrasena invalida.",
+        "passphraseRequired": "Se requiere contraseña.",
+        "invalidPassphrase": "Contraseña invalida.",
         "exportFailed": "No se pudo exportar el vault."
       }
     },
     "categories": {
+      "general": "General",
+      "generalDesc": "Preferencias de idioma y tema",
       "security": "Seguridad",
-      "securityDesc": "Contrasena, bloqueo automatico y restablecer",
+      "securityDesc": "Contraseña, bloqueo automatico y restablecer",
       "backup": "Respaldo",
       "backupDesc": "Exportar tu archivo vault",
       "accounts": "Administrar cuentas",
@@ -122,18 +124,22 @@
       "about": "Acerca de",
       "aboutDesc": "Version de la aplicacion e informacion"
     },
+    "general": {
+      "title": "General",
+      "back": "Configuración"
+    },
     "security": {
       "title": "Seguridad",
       "back": "Ajustes",
-      "changePassword": "Cambiar contrasena",
-      "changePasswordDesc": "Actualizar la contrasena de tu vault",
-      "changePasswordDrawerTitle": "Cambiar contrasena",
-      "changePasswordDrawerDesc": "Ingresa tu contrasena actual y elige una nueva.",
-      "currentPassphrase": "Contrasena actual",
-      "newPassphrase": "Nueva contrasena",
-      "confirmPassphrase": "Confirmar nueva contrasena",
+      "changePassword": "Cambiar contraseña",
+      "changePasswordDesc": "Actualizar la contraseña de tu vault",
+      "changePasswordDrawerTitle": "Cambiar contraseña",
+      "changePasswordDrawerDesc": "Ingresa tu contraseña actual y elige una nueva.",
+      "currentPassphrase": "Contraseña actual",
+      "newPassphrase": "Nueva contraseña",
+      "confirmPassphrase": "Confirmar nueva contraseña",
       "minChars": "Minimo 12 caracteres.",
-      "save": "Guardar nueva contrasena",
+      "save": "Guardar nueva contraseña",
       "saving": "Guardando...",
       "cancel": "Cancelar",
       "resetApp": "Eliminar billetera",
@@ -141,19 +147,19 @@
       "resetAppDesc": "Esto borrara todos los datos incluyendo tu vault, cuentas y ajustes. Esta accion no se puede deshacer. Asegurate de haber respaldado tus semillas.",
       "resetAppConfirm": "Eliminar billetera",
       "errors": {
-        "currentRequired": "Se requiere contrasena actual.",
-        "newRequired": "Se requiere nueva contrasena.",
-        "confirmRequired": "Confirma tu nueva contrasena.",
-        "tooShort": "La contrasena debe tener al menos 12 caracteres.",
-        "mismatch": "Las contrasenas no coinciden.",
-        "invalidCurrent": "La contrasena actual es incorrecta.",
-        "changeFailed": "No se pudo cambiar la contrasena. Intenta de nuevo."
+        "currentRequired": "Se requiere contraseña actual.",
+        "newRequired": "Se requiere nueva contraseña.",
+        "confirmRequired": "Confirma tu nueva contraseña.",
+        "tooShort": "La contraseña debe tener al menos 12 caracteres.",
+        "mismatch": "Las contraseñas no coinciden.",
+        "invalidCurrent": "La contraseña actual es incorrecta.",
+        "changeFailed": "No se pudo cambiar la contraseña. Intenta de nuevo."
       }
     },
     "support": {
       "title": "Soporte",
       "warningTitle": "Cuidado con los estafadores",
-      "warningDescription": "Los miembros del equipo de Qubic nunca te pediran tu semilla o contrasena. Nunca compartas tus claves privadas con nadie.",
+      "warningDescription": "Los miembros del equipo de Qubic nunca te pediran tu semilla o contraseña. Nunca compartas tus claves privadas con nadie.",
       "discord": "Comunidad de Discord",
       "github": "Reportar un problema en GitHub"
     },
@@ -173,7 +179,7 @@
     "manage": {
       "title": "Administrar cuentas",
       "subtitle": "Ver, ordenar y gestionar tus identidades.",
-      "passphrase": "Contrasena del vault",
+      "passphrase": "Contraseña del vault",
       "passphraseTitle": "Desbloquear vault",
       "load": "Cargar cuentas",
       "unlock": "Desbloquear vault",
@@ -213,8 +219,8 @@
         "rename": "No se pudo renombrar la cuenta.",
         "reveal": "No se pudo mostrar la semilla.",
         "nameRequired": "Se requiere nombre de cuenta.",
-        "passphraseRequired": "Se requiere contrasena.",
-        "invalidPassphrase": "Contrasena invalida.",
+        "passphraseRequired": "Se requiere contraseña.",
+        "invalidPassphrase": "Contraseña invalida.",
         "nameDuplicate": "Ya existe una cuenta con este nombre.",
         "watchOnlySeed": "Las cuentas de solo lectura no tienen semilla.",
         "watchOnlyRequired": "Se requiere nombre e identidad.",
@@ -343,17 +349,17 @@
   },
   "passphraseAuth": {
     "title": "Autenticacion Requerida",
-    "subtitle": "Ingresa tu contrasena del vault para continuar con esta accion.",
+    "subtitle": "Ingresa tu contraseña del vault para continuar con esta accion.",
     "form": {
-      "passphrase": "Contrasena del vault",
-      "passphrasePlaceholder": "Ingresa tu contrasena",
-      "showPassphrase": "Mostrar contrasena",
-      "hidePassphrase": "Ocultar contrasena"
+      "passphrase": "Contraseña del vault",
+      "passphrasePlaceholder": "Ingresa tu contraseña",
+      "showPassphrase": "Mostrar contraseña",
+      "hidePassphrase": "Ocultar contraseña"
     },
     "validation": {
-      "required": "Se requiere contrasena."
+      "required": "Se requiere contraseña."
     },
-    "securityNote": "Tu contrasena se usa localmente para descifrar tu vault y firmar transacciones. Nunca se transmite por la red.",
+    "securityNote": "Tu contraseña se usa localmente para descifrar tu vault y firmar transacciones. Nunca se transmite por la red.",
     "actions": {
       "back": "Atras",
       "cancel": "Cancelar",
@@ -361,14 +367,14 @@
       "unlocking": "Desbloqueando..."
     },
     "errors": {
-      "invalidPassphrase": "Contrasena invalida. Intenta de nuevo.",
+      "invalidPassphrase": "Contraseña invalida. Intenta de nuevo.",
       "accountNotFound": "Cuenta no encontrada en el vault.",
       "generic": "Autenticacion fallida. Intenta de nuevo."
     }
   },
   "unlock": {
     "title": "Desbloquea tu billetera",
-    "subtitle": "Tu billetera esta bloqueada por seguridad. Ingresa tu contrasena para continuar."
+    "subtitle": "Tu billetera esta bloqueada por seguridad. Ingresa tu contraseña para continuar."
   },
   "onboarding": {
     "importVault": {
@@ -383,18 +389,18 @@
       },
       "unlockSecure": {
         "title": "Desbloquear y asegurar",
-        "subtitle": "Proporciona una nueva contrasena para este dispositivo y, si es necesario, la contrasena de origen.",
-        "newPassphrase": "Nueva contrasena del vault",
-        "sourcePassphrase": "Contrasena del vault de origen"
+        "subtitle": "Proporciona una nueva contraseña para este dispositivo y, si es necesario, la contraseña de origen.",
+        "newPassphrase": "Nueva contraseña del vault",
+        "sourcePassphrase": "Contraseña del vault de origen"
       },
       "review": {
         "title": "Revisar importacion",
-        "subtitle": "Confirma los detalles del archivo y la contrasena antes de importar.",
+        "subtitle": "Confirma los detalles del archivo y la contraseña antes de importar.",
         "vaultFile": "Archivo vault",
         "notSelected": "No seleccionado",
         "sourcePassphraseProvided": "Proporcionada",
         "sourcePassphraseSame": "Igual que la nueva",
-        "sourcePassphraseLabel": "Contrasena de origen",
+        "sourcePassphraseLabel": "Contraseña de origen",
         "addMoreLater": "Puedes agregar mas cuentas mas tarde en Administrar Cuentas."
       },
       "actions": {
@@ -406,7 +412,7 @@
       },
       "errors": {
         "selectFile": "Selecciona un archivo vault.",
-        "passphraseRequired": "Se requiere contrasena.",
+        "passphraseRequired": "Se requiere contraseña.",
         "importFailed": "No se pudo importar el vault de la billetera web.",
         "noEntries": "Vault importado pero no se encontraron entradas.",
         "generic": "No se pudo importar el vault."

--- a/src/pages/manage-accounts.tsx
+++ b/src/pages/manage-accounts.tsx
@@ -671,7 +671,8 @@ const ManageAccounts = () => {
           </DrawerHeader>
           <DrawerFooter>
             <Button
-              variant="destructive"
+              variant="destructive-outline"
+              className="w-full"
               onClick={() => {
                 if (removeTarget) {
                   if (removeTarget.watchOnly) {

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { useTheme } from 'next-themes'
 import { useNavigate } from 'react-router-dom'
 import { VaultInvalidPassphraseError } from '@qubic-labs/sdk'
 import {
@@ -13,6 +12,7 @@ import {
   LifeBuoyIcon,
   LockIcon,
   ShieldIcon,
+  SlidersHorizontalIcon,
   UsersIcon,
 } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -26,15 +26,7 @@ import {
 } from '@/components/ui/drawer'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import { Separator } from '@/components/ui/separator'
-import { setLanguage } from '@/i18n'
 import { lockWallet } from '@/lib/lock'
 import { openBrowserVault } from '@/lib/vault'
 import { exportVaultToWebWalletFormat } from '@/lib/vault-export'
@@ -44,8 +36,7 @@ declare const __APP_VERSION__: string
 const appVersion = typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : '0.0.0'
 
 const Settings = () => {
-  const { t, i18n } = useTranslation()
-  const { theme, setTheme } = useTheme()
+  const { t } = useTranslation()
   const navigate = useNavigate()
 
   const [exportDrawerOpen, setExportDrawerOpen] = useState(false)
@@ -103,6 +94,13 @@ const Settings = () => {
 
   const categories = [
     {
+      key: 'general',
+      icon: SlidersHorizontalIcon,
+      label: t('settings.categories.general'),
+      description: t('settings.categories.generalDesc'),
+      action: () => navigate('/settings/general'),
+    },
+    {
       key: 'security',
       icon: ShieldIcon,
       label: t('settings.categories.security'),
@@ -143,42 +141,6 @@ const Settings = () => {
     <>
       <section className="flex w-full justify-center pt-4">
         <div className="flex w-full max-w-sm flex-col gap-6 px-4">
-          <div className="space-y-3">
-            <Label htmlFor="language" className="text-sm text-muted-foreground">
-              {t('settings.language')}
-            </Label>
-            <Select
-              value={i18n.language}
-              onValueChange={(value) => setLanguage(value as 'en' | 'es')}
-            >
-              <SelectTrigger id="language" className="h-9 w-full text-sm">
-                <SelectValue placeholder="EN" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="en">EN</SelectItem>
-                <SelectItem value="es">ES</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-3">
-            <Label htmlFor="theme" className="text-sm text-muted-foreground">
-              {t('settings.theme')}
-            </Label>
-            <Select value={theme} onValueChange={setTheme}>
-              <SelectTrigger id="theme" className="h-9 w-full text-sm">
-                <SelectValue placeholder={t('settings.themeDark')} />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="dark">{t('settings.themeDark')}</SelectItem>
-                <SelectItem value="light">{t('settings.themeLight')}</SelectItem>
-                <SelectItem value="system">{t('settings.themeSystem')}</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-
-          <Separator />
-
           <div className="space-y-2">
             {categories.map((cat) => (
               <button

--- a/src/pages/settings/general.tsx
+++ b/src/pages/settings/general.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from 'react-i18next'
+import { useNavigate } from 'react-router-dom'
+import { useTheme } from 'next-themes'
+import { ArrowLeftIcon } from 'lucide-react'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { setLanguage } from '@/i18n'
+
+const General = () => {
+  const { t, i18n } = useTranslation()
+  const navigate = useNavigate()
+  const { theme, setTheme } = useTheme()
+
+  return (
+    <section className="flex w-full justify-center pt-4">
+      <div className="flex w-full max-w-sm flex-col gap-6 px-4">
+        <button
+          type="button"
+          onClick={() => navigate('/settings')}
+          className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeftIcon className="h-4 w-4" />
+          {t('settings.general.back')}
+        </button>
+
+        <h2 className="text-base font-semibold">{t('settings.general.title')}</h2>
+
+        <div className="space-y-3">
+          <Label htmlFor="language" className="text-sm text-muted-foreground">
+            {t('settings.language')}
+          </Label>
+          <Select
+            value={i18n.language}
+            onValueChange={(value) => setLanguage(value as 'en' | 'es')}
+          >
+            <SelectTrigger id="language" className="h-9 w-full text-sm">
+              <SelectValue placeholder="English" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="en">English</SelectItem>
+              <SelectItem value="es">Español</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="space-y-3">
+          <Label htmlFor="theme" className="text-sm text-muted-foreground">
+            {t('settings.theme')}
+          </Label>
+          <Select value={theme} onValueChange={setTheme}>
+            <SelectTrigger id="theme" className="h-9 w-full text-sm">
+              <SelectValue placeholder={t('settings.themeDark')} />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="dark">{t('settings.themeDark')}</SelectItem>
+              <SelectItem value="light">{t('settings.themeLight')}</SelectItem>
+              <SelectItem value="system">{t('settings.themeSystem')}</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default General

--- a/src/pages/settings/security.tsx
+++ b/src/pages/settings/security.tsx
@@ -170,7 +170,11 @@ const Security = () => {
 
           <Separator />
 
-          <Button variant="destructive" onClick={() => setResetAppOpen(true)}>
+          <Button
+            variant="destructive-outline"
+            className="w-full"
+            onClick={() => setResetAppOpen(true)}
+          >
             <TrashIcon className="h-4 w-4" />
             {t('settings.security.resetApp')}
           </Button>

--- a/src/router/app-router.tsx
+++ b/src/router/app-router.tsx
@@ -11,6 +11,7 @@ import ImportSeed from '../pages/onboarding/import-seed'
 import ImportVault from '../pages/onboarding/import-vault'
 import Transfer from '../pages/transfer'
 import Settings from '../pages/settings'
+import General from '../pages/settings/general'
 import Security from '../pages/settings/security'
 import TransactionDetails from '../pages/transaction-details'
 import Unlock from '../pages/unlock'
@@ -221,6 +222,14 @@ const AppRouter = () => {
             element={
               <AnimatedRoute>
                 <Settings />
+              </AnimatedRoute>
+            }
+          />
+          <Route
+            path="/settings/general"
+            element={
+              <AnimatedRoute>
+                <General />
               </AnimatedRoute>
             }
           />


### PR DESCRIPTION
- Move language and theme selectors from the main settings page into a new "General" settings sub-page, keeping the settings hub clean and consistent with the existing sub-page pattern (Security)
- Add a reusable `destructive-outline` button variant and apply it to delete wallet / remove account actions
- Fix missing tildes in Spanish locale ("Contrasena" → "Contraseña")