### PR TITLE
fix(lock): harden auto-lock behavior for inactivity + browser restart

### DIFF
--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -1,9 +1,43 @@
 const LOCKED_KEY = 'walletLocked'
 const LAST_UNLOCK_AT_KEY = 'walletLastUnlockAt'
 const LOCK_TIMEOUT_MINUTES_KEY = 'walletLockTimeoutMinutes'
-export const DEFAULT_LOCK_TIMEOUT_MINUTES = 10
+const SESSION_UNLOCKED_KEY = 'walletSessionUnlocked'
+export const DEFAULT_LOCK_TIMEOUT_MINUTES = 15
 const MIN_LOCK_TIMEOUT_MINUTES = 1
 const MAX_LOCK_TIMEOUT_MINUTES = 120
+
+type ChromeStorageSession = {
+  get: (keys: string[], callback: (items: Record<string, unknown>) => void) => void
+  set: (items: Record<string, unknown>, callback?: () => void) => void
+  remove: (keys: string | string[], callback?: () => void) => void
+}
+
+const getChromeSessionStorage = (): ChromeStorageSession | null => {
+  if (typeof window === 'undefined') return null
+
+  const maybeChrome = (
+    window as Window & {
+      chrome?: { storage?: { session?: ChromeStorageSession } }
+    }
+  ).chrome
+
+  return maybeChrome?.storage?.session ?? null
+}
+
+const setSessionUnlockedFlag = (value: boolean) => {
+  const sessionStorage = getChromeSessionStorage()
+  if (!sessionStorage) return
+
+  try {
+    if (value) {
+      sessionStorage.set({ [SESSION_UNLOCKED_KEY]: true })
+      return
+    }
+    sessionStorage.remove(SESSION_UNLOCKED_KEY)
+  } catch {
+    // Ignore storage failures.
+  }
+}
 
 const notifyLockUpdate = () => {
   if (typeof window === 'undefined') return
@@ -40,6 +74,7 @@ export const lockWallet = () => {
   } catch {
     // Ignore storage failures.
   }
+  setSessionUnlockedFlag(false)
   notifyLockUpdate()
 }
 
@@ -50,6 +85,7 @@ export const setUnlocked = () => {
   } catch {
     // Ignore storage failures.
   }
+  setSessionUnlockedFlag(true)
   notifyLockUpdate()
 }
 
@@ -88,4 +124,31 @@ export const isWalletLocked = () => {
   const lastUnlockAt = getLastUnlockAt()
   if (!lastUnlockAt) return true
   return Date.now() - lastUnlockAt >= getLockTimeoutMs()
+}
+
+const readSessionUnlockedFlag = async () => {
+  const sessionStorage = getChromeSessionStorage()
+  if (!sessionStorage) return true
+
+  return new Promise<boolean>((resolve) => {
+    try {
+      sessionStorage.get([SESSION_UNLOCKED_KEY], (items) => {
+        resolve(items?.[SESSION_UNLOCKED_KEY] === true)
+      })
+    } catch {
+      resolve(true)
+    }
+  })
+}
+
+export const reconcileLockStateWithBrowserSession = async () => {
+  if (isWalletLocked()) return true
+
+  const hasActiveSession = await readSessionUnlockedFlag()
+  if (!hasActiveSession) {
+    lockWallet()
+    return true
+  }
+
+  return false
 }

--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -147,24 +147,11 @@ export const isWalletLocked = () => {
 }
 
 const normalizeLockTimeoutOption = (minutes: number) => {
-  if (
-    LOCK_TIMEOUT_OPTIONS_MINUTES.includes(minutes as (typeof LOCK_TIMEOUT_OPTIONS_MINUTES)[number])
-  ) {
-    return minutes
-  }
-
-  let nearest = DEFAULT_LOCK_TIMEOUT_MINUTES
-  let nearestDistance = Number.POSITIVE_INFINITY
-
-  for (const option of LOCK_TIMEOUT_OPTIONS_MINUTES) {
-    const distance = Math.abs(option - minutes)
-    if (distance < nearestDistance) {
-      nearest = option
-      nearestDistance = distance
-    }
-  }
-
-  return nearest
+  return LOCK_TIMEOUT_OPTIONS_MINUTES.includes(
+    minutes as (typeof LOCK_TIMEOUT_OPTIONS_MINUTES)[number],
+  )
+    ? minutes
+    : DEFAULT_LOCK_TIMEOUT_MINUTES
 }
 
 const readSessionUnlockedFlag = async () => {

--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -2,9 +2,12 @@ const LOCKED_KEY = 'walletLocked'
 const LAST_UNLOCK_AT_KEY = 'walletLastUnlockAt'
 const LOCK_TIMEOUT_MINUTES_KEY = 'walletLockTimeoutMinutes'
 const SESSION_UNLOCKED_KEY = 'walletSessionUnlocked'
+export const LOCK_TIMEOUT_OPTIONS_MINUTES = [0, 1, 3, 5, 10, 15, 20, 30, 45, 60] as const
 export const DEFAULT_LOCK_TIMEOUT_MINUTES = 15
-const MIN_LOCK_TIMEOUT_MINUTES = 1
+const MIN_LOCK_TIMEOUT_MINUTES = 0
 const MAX_LOCK_TIMEOUT_MINUTES = 120
+const ACTIVITY_TOUCH_THROTTLE_MS = 1_000
+let lastActivityTouchAt = 0
 
 type ChromeStorageSession = {
   get: (keys: string[], callback: (items: Record<string, unknown>) => void) => void
@@ -50,7 +53,8 @@ export const getLockTimeoutMinutes = () => {
     if (!raw) return DEFAULT_LOCK_TIMEOUT_MINUTES
     const parsed = Number(raw)
     if (!Number.isFinite(parsed)) return DEFAULT_LOCK_TIMEOUT_MINUTES
-    return Math.min(MAX_LOCK_TIMEOUT_MINUTES, Math.max(MIN_LOCK_TIMEOUT_MINUTES, parsed))
+    const clamped = Math.min(MAX_LOCK_TIMEOUT_MINUTES, Math.max(MIN_LOCK_TIMEOUT_MINUTES, parsed))
+    return normalizeLockTimeoutOption(clamped)
   } catch {
     return DEFAULT_LOCK_TIMEOUT_MINUTES
   }
@@ -58,8 +62,9 @@ export const getLockTimeoutMinutes = () => {
 
 export const setLockTimeoutMinutes = (minutes: number) => {
   const clamped = Math.min(MAX_LOCK_TIMEOUT_MINUTES, Math.max(MIN_LOCK_TIMEOUT_MINUTES, minutes))
+  const normalized = normalizeLockTimeoutOption(clamped)
   try {
-    localStorage.setItem(LOCK_TIMEOUT_MINUTES_KEY, clamped.toString())
+    localStorage.setItem(LOCK_TIMEOUT_MINUTES_KEY, normalized.toString())
   } catch {
     // Ignore storage failures.
   }
@@ -87,6 +92,18 @@ export const setUnlocked = () => {
   }
   setSessionUnlockedFlag(true)
   notifyLockUpdate()
+}
+
+export const touchWalletActivity = () => {
+  const now = Date.now()
+  if (now - lastActivityTouchAt < ACTIVITY_TOUCH_THROTTLE_MS) return
+  lastActivityTouchAt = now
+  try {
+    if (localStorage.getItem(LOCKED_KEY) === 'true') return
+    localStorage.setItem(LAST_UNLOCK_AT_KEY, now.toString())
+  } catch {
+    // Ignore storage failures.
+  }
 }
 
 export const getLastUnlockAt = () => {
@@ -121,9 +138,33 @@ export const isWalletLocked = () => {
     return true
   }
 
+  const timeoutMs = getLockTimeoutMs()
+  if (timeoutMs <= 0) return false
+
   const lastUnlockAt = getLastUnlockAt()
   if (!lastUnlockAt) return true
-  return Date.now() - lastUnlockAt >= getLockTimeoutMs()
+  return Date.now() - lastUnlockAt >= timeoutMs
+}
+
+const normalizeLockTimeoutOption = (minutes: number) => {
+  if (
+    LOCK_TIMEOUT_OPTIONS_MINUTES.includes(minutes as (typeof LOCK_TIMEOUT_OPTIONS_MINUTES)[number])
+  ) {
+    return minutes
+  }
+
+  let nearest = DEFAULT_LOCK_TIMEOUT_MINUTES
+  let nearestDistance = Number.POSITIVE_INFINITY
+
+  for (const option of LOCK_TIMEOUT_OPTIONS_MINUTES) {
+    const distance = Math.abs(option - minutes)
+    if (distance < nearestDistance) {
+      nearest = option
+      nearestDistance = distance
+    }
+  }
+
+  return nearest
 }
 
 const readSessionUnlockedFlag = async () => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -92,7 +92,9 @@
     "lockNow": "Lock wallet",
     "lockTimeout": {
       "label": "Auto-lock timeout (minutes)",
-      "helper": "Locks the wallet after the selected duration."
+      "helper": "Locks the wallet after the selected duration.",
+      "option": "{{minutes}} min",
+      "immediately": "Immediately"
     },
     "exportVault": {
       "button": "Export vault",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -92,7 +92,9 @@
     "lockNow": "Bloquear billetera",
     "lockTimeout": {
       "label": "Tiempo de bloqueo (minutos)",
-      "helper": "Bloquea la billetera después del tiempo seleccionado."
+      "helper": "Bloquea la billetera después del tiempo seleccionado.",
+      "option": "{{minutes}} min",
+      "immediately": "Inmediatamente"
     },
     "exportVault": {
       "button": "Exportar vault",

--- a/src/pages/settings/security.tsx
+++ b/src/pages/settings/security.tsx
@@ -24,8 +24,20 @@ import {
 } from '@/components/ui/drawer'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Separator } from '@/components/ui/separator'
-import { getLockTimeoutMinutes, lockWallet, setLockTimeoutMinutes } from '@/lib/lock'
+import {
+  getLockTimeoutMinutes,
+  LOCK_TIMEOUT_OPTIONS_MINUTES,
+  lockWallet,
+  setLockTimeoutMinutes,
+} from '@/lib/lock'
 import { clearWalletStorage } from '@/lib/storage'
 import { changeVaultPassphrase } from '@/lib/vault-password'
 
@@ -50,14 +62,9 @@ const Security = () => {
 
   const handleTimeoutChange = (value: string) => {
     const parsed = Number(value)
-    if (!Number.isFinite(parsed)) {
-      setLockMinutes(0)
-      return
-    }
+    if (!Number.isFinite(parsed)) return
     setLockMinutes(parsed)
-    if (parsed > 0) {
-      setLockTimeoutMinutes(parsed)
-    }
+    setLockTimeoutMinutes(parsed)
   }
 
   const resetChangePasswordForm = () => {
@@ -153,19 +160,20 @@ const Security = () => {
             <Label htmlFor="lock-timeout" className="text-sm text-muted-foreground">
               {t('settings.lockTimeout.label')}
             </Label>
-            <Input
-              id="lock-timeout"
-              type="number"
-              min={1}
-              max={120}
-              value={Number.isFinite(lockMinutes) ? lockMinutes : ''}
-              onChange={(event) => handleTimeoutChange(event.target.value)}
-              onBlur={() => {
-                if (lockMinutes <= 0) {
-                  setLockMinutes(getLockTimeoutMinutes())
-                }
-              }}
-            />
+            <Select value={lockMinutes.toString()} onValueChange={handleTimeoutChange}>
+              <SelectTrigger id="lock-timeout" className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {LOCK_TIMEOUT_OPTIONS_MINUTES.map((minutes) => (
+                  <SelectItem key={minutes} value={minutes.toString()}>
+                    {minutes === 0
+                      ? t('settings.lockTimeout.immediately')
+                      : t('settings.lockTimeout.option', { minutes })}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
             <p className="text-xs text-muted-foreground">{t('settings.lockTimeout.helper')}</p>
           </div>
 

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -20,6 +20,7 @@ import {
   PENDING_SETTLED_EVENT,
   usePendingTransactionsVersion,
 } from '@/lib/pending-transactions'
+import { isWalletLocked } from '@/lib/lock'
 import { useLatestStats } from '@/lib/network-stats'
 import ConfirmationDrawer from '@/components/pages/transfer/confirmation-drawer'
 import TransferForm from '@/components/pages/transfer/transfer-form'
@@ -147,6 +148,21 @@ const Transfer = () => {
       window.removeEventListener(PENDING_SETTLED_EVENT, handlePendingSettled)
     }
   }, [balance, latestStats])
+
+  useEffect(() => {
+    const handleLockUpdate = () => {
+      if (!isWalletLocked()) return
+      seedRef.current = null
+      setDrawerOpen(false)
+      setStep('form')
+      setSending(false)
+    }
+
+    window.addEventListener('wallet-lock-updated', handleLockUpdate)
+    return () => {
+      window.removeEventListener('wallet-lock-updated', handleLockUpdate)
+    }
+  }, [])
 
   const validateForm = (): boolean => {
     const newErrors: FormErrors = {}

--- a/src/router/app-router.tsx
+++ b/src/router/app-router.tsx
@@ -24,6 +24,7 @@ import {
   isWalletLocked,
   lockWallet,
   reconcileLockStateWithBrowserSession,
+  touchWalletActivity,
 } from '../lib/lock'
 import { getCurrentIdentity } from '../lib/accounts'
 
@@ -54,6 +55,10 @@ const AppRouter = () => {
 
   const scheduleLock = useCallback(() => {
     clearLockTimeout()
+    const lockTimeoutMs = getLockTimeoutMs()
+    if (lockTimeoutMs <= 0) {
+      return
+    }
     const lastUnlockAt = getLastUnlockAt()
     if (!lastUnlockAt) {
       lockWallet()
@@ -61,7 +66,7 @@ const AppRouter = () => {
       return
     }
     const elapsed = Date.now() - lastUnlockAt
-    const remaining = getLockTimeoutMs() - elapsed
+    const remaining = lockTimeoutMs - elapsed
     if (remaining <= 0) {
       lockWallet()
       setIsLocked(true)
@@ -102,6 +107,36 @@ const AppRouter = () => {
       clearLockTimeout()
     }
   }, [clearLockTimeout, isLocked, isOnboarded, scheduleLock])
+
+  useEffect(() => {
+    if (!isOnboarded) return undefined
+    if (isLocked) return undefined
+
+    const recordActivity = () => {
+      touchWalletActivity()
+      scheduleLock()
+    }
+
+    const lockOnClose = () => {
+      if (getLockTimeoutMs() <= 0) {
+        lockWallet()
+      }
+    }
+
+    window.addEventListener('pointerdown', recordActivity, { passive: true })
+    window.addEventListener('keydown', recordActivity, { passive: true })
+    window.addEventListener('touchstart', recordActivity, { passive: true })
+    window.addEventListener('beforeunload', lockOnClose)
+    window.addEventListener('pagehide', lockOnClose)
+
+    return () => {
+      window.removeEventListener('pointerdown', recordActivity)
+      window.removeEventListener('keydown', recordActivity)
+      window.removeEventListener('touchstart', recordActivity)
+      window.removeEventListener('beforeunload', lockOnClose)
+      window.removeEventListener('pagehide', lockOnClose)
+    }
+  }, [isLocked, isOnboarded, scheduleLock])
 
   useEffect(() => {
     if (!isOnboarded) return undefined

--- a/src/router/app-router.tsx
+++ b/src/router/app-router.tsx
@@ -23,6 +23,7 @@ import {
   getLastUnlockAt,
   isWalletLocked,
   lockWallet,
+  reconcileLockStateWithBrowserSession,
 } from '../lib/lock'
 import { getCurrentIdentity } from '../lib/accounts'
 
@@ -74,9 +75,20 @@ const AppRouter = () => {
 
   useEffect(() => {
     if (!isOnboarded) return undefined
-    ensureUnlockTimestamp()
-    setIsLocked(isWalletLocked())
-    return undefined
+    let isDisposed = false
+
+    const syncLockState = async () => {
+      ensureUnlockTimestamp()
+      await reconcileLockStateWithBrowserSession()
+      if (isDisposed) return
+      setIsLocked(isWalletLocked())
+    }
+
+    void syncLockState()
+
+    return () => {
+      isDisposed = true
+    }
   }, [isOnboarded])
 
   useEffect(() => {


### PR DESCRIPTION
- Set default auto-lock timeout to 15 minutes.
- Added browser-session based lock validation:
    - On app init, if local unlock state exists but browser session unlock marker is missing, wallet is locked.
- Kept manual lock flow intact from Settings.
- Cleared decrypted transfer seed state immediately when lock events occur.