### PR TITLE
fix(accounts): prevent removing the last account

### DIFF
--- a/src/lib/lock.ts
+++ b/src/lib/lock.ts
@@ -1,9 +1,43 @@
 const LOCKED_KEY = 'walletLocked'
 const LAST_UNLOCK_AT_KEY = 'walletLastUnlockAt'
 const LOCK_TIMEOUT_MINUTES_KEY = 'walletLockTimeoutMinutes'
-export const DEFAULT_LOCK_TIMEOUT_MINUTES = 10
+const SESSION_UNLOCKED_KEY = 'walletSessionUnlocked'
+export const DEFAULT_LOCK_TIMEOUT_MINUTES = 15
 const MIN_LOCK_TIMEOUT_MINUTES = 1
 const MAX_LOCK_TIMEOUT_MINUTES = 120
+
+type ChromeStorageSession = {
+  get: (keys: string[], callback: (items: Record<string, unknown>) => void) => void
+  set: (items: Record<string, unknown>, callback?: () => void) => void
+  remove: (keys: string | string[], callback?: () => void) => void
+}
+
+const getChromeSessionStorage = (): ChromeStorageSession | null => {
+  if (typeof window === 'undefined') return null
+
+  const maybeChrome = (
+    window as Window & {
+      chrome?: { storage?: { session?: ChromeStorageSession } }
+    }
+  ).chrome
+
+  return maybeChrome?.storage?.session ?? null
+}
+
+const setSessionUnlockedFlag = (value: boolean) => {
+  const sessionStorage = getChromeSessionStorage()
+  if (!sessionStorage) return
+
+  try {
+    if (value) {
+      sessionStorage.set({ [SESSION_UNLOCKED_KEY]: true })
+      return
+    }
+    sessionStorage.remove(SESSION_UNLOCKED_KEY)
+  } catch {
+    // Ignore storage failures.
+  }
+}
 
 const notifyLockUpdate = () => {
   if (typeof window === 'undefined') return
@@ -40,6 +74,7 @@ export const lockWallet = () => {
   } catch {
     // Ignore storage failures.
   }
+  setSessionUnlockedFlag(false)
   notifyLockUpdate()
 }
 
@@ -50,6 +85,7 @@ export const setUnlocked = () => {
   } catch {
     // Ignore storage failures.
   }
+  setSessionUnlockedFlag(true)
   notifyLockUpdate()
 }
 
@@ -88,4 +124,31 @@ export const isWalletLocked = () => {
   const lastUnlockAt = getLastUnlockAt()
   if (!lastUnlockAt) return true
   return Date.now() - lastUnlockAt >= getLockTimeoutMs()
+}
+
+const readSessionUnlockedFlag = async () => {
+  const sessionStorage = getChromeSessionStorage()
+  if (!sessionStorage) return true
+
+  return new Promise<boolean>((resolve) => {
+    try {
+      sessionStorage.get([SESSION_UNLOCKED_KEY], (items) => {
+        resolve(items?.[SESSION_UNLOCKED_KEY] === true)
+      })
+    } catch {
+      resolve(true)
+    }
+  })
+}
+
+export const reconcileLockStateWithBrowserSession = async () => {
+  if (isWalletLocked()) return true
+
+  const hasActiveSession = await readSessionUnlockedFlag()
+  if (!hasActiveSession) {
+    lockWallet()
+    return true
+  }
+
+  return false
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -222,6 +222,7 @@
         "passphraseRequired": "Passphrase is required.",
         "invalidPassphrase": "Invalid passphrase.",
         "nameDuplicate": "An account with this name already exists.",
+        "lastAccount": "You cannot remove the last account.",
         "watchOnlySeed": "Watch-only accounts do not have a seed.",
         "watchOnlyRequired": "Name and identity are required.",
         "watchOnlyInvalid": "Identity format is invalid.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -222,6 +222,7 @@
         "passphraseRequired": "Se requiere contraseña.",
         "invalidPassphrase": "Contraseña invalida.",
         "nameDuplicate": "Ya existe una cuenta con este nombre.",
+        "lastAccount": "No puedes eliminar la ultima cuenta.",
         "watchOnlySeed": "Las cuentas de solo lectura no tienen semilla.",
         "watchOnlyRequired": "Se requiere nombre e identidad.",
         "watchOnlyInvalid": "Formato de identidad invalido.",

--- a/src/pages/manage-accounts.tsx
+++ b/src/pages/manage-accounts.tsx
@@ -164,6 +164,8 @@ const ManageAccounts = () => {
     return map
   }, [balanceQueries, orderedAccounts])
 
+  const canRemoveAnyAccount = orderedAccounts.length > 1
+
   const loadAccounts = async (passphrase: string) => {
     setStatus(null)
     setLoading(true)
@@ -241,6 +243,11 @@ const ManageAccounts = () => {
   }
 
   const handleRemove = async (account: AccountEntry, passphrase: string) => {
+    if (orderedAccounts.length <= 1) {
+      setStatus(t('accounts.manage.errors.lastAccount'))
+      return
+    }
+
     setStatus(null)
     setLoading(true)
     try {
@@ -486,6 +493,7 @@ const ManageAccounts = () => {
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
                         variant="destructive"
+                        disabled={!canRemoveAnyAccount}
                         onClick={() => setRemoveTarget(account)}
                       >
                         <TrashIcon className="h-4 w-4" />
@@ -668,10 +676,16 @@ const ManageAccounts = () => {
             <DrawerTitle>{t('accounts.manage.removeTitle')}</DrawerTitle>
             <DrawerDescription>{t('accounts.manage.removeDesc')}</DrawerDescription>
           </DrawerHeader>
+          {!canRemoveAnyAccount && (
+            <p className="px-4 text-xs text-destructive">
+              {t('accounts.manage.errors.lastAccount')}
+            </p>
+          )}
           <DrawerFooter>
             <Button
               variant="destructive-outline"
               className="w-full"
+              disabled={!canRemoveAnyAccount}
               onClick={() => {
                 if (removeTarget) {
                   if (removeTarget.watchOnly) {

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -64,6 +64,7 @@ import {
   PENDING_SETTLED_EVENT,
   usePendingTransactionsVersion,
 } from '@/lib/pending-transactions'
+import { isWalletLocked } from '@/lib/lock'
 import { setOnboarded } from '@/lib/vault'
 
 type Step = 'form' | 'auth' | 'success'
@@ -848,6 +849,21 @@ const Transfer = () => {
       window.removeEventListener(PENDING_SETTLED_EVENT, handlePendingSettled)
     }
   }, [balance, latestStats])
+
+  useEffect(() => {
+    const handleLockUpdate = () => {
+      if (!isWalletLocked()) return
+      seedRef.current = null
+      setDrawerOpen(false)
+      setStep('form')
+      setSending(false)
+    }
+
+    window.addEventListener('wallet-lock-updated', handleLockUpdate)
+    return () => {
+      window.removeEventListener('wallet-lock-updated', handleLockUpdate)
+    }
+  }, [])
 
   const validateForm = (): boolean => {
     const newErrors: FormErrors = {}

--- a/src/router/app-router.tsx
+++ b/src/router/app-router.tsx
@@ -23,6 +23,7 @@ import {
   getLastUnlockAt,
   isWalletLocked,
   lockWallet,
+  reconcileLockStateWithBrowserSession,
 } from '../lib/lock'
 import { getCurrentIdentity } from '../lib/accounts'
 
@@ -74,9 +75,20 @@ const AppRouter = () => {
 
   useEffect(() => {
     if (!isOnboarded) return undefined
-    ensureUnlockTimestamp()
-    setIsLocked(isWalletLocked())
-    return undefined
+    let isDisposed = false
+
+    const syncLockState = async () => {
+      ensureUnlockTimestamp()
+      await reconcileLockStateWithBrowserSession()
+      if (isDisposed) return
+      setIsLocked(isWalletLocked())
+    }
+
+    void syncLockState()
+
+    return () => {
+      isDisposed = true
+    }
   }, [isOnboarded])
 
   useEffect(() => {


### PR DESCRIPTION
- Prevent removing the last remaining account in Manage Accounts.
- Disable the remove action when only one account exists.
- Show a clear validation/error message for this case.
- Added locale strings for EN/ES.