### PR TITLE
fix(accounts): prevent removing the last account

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -222,6 +222,7 @@
         "passphraseRequired": "Passphrase is required.",
         "invalidPassphrase": "Invalid passphrase.",
         "nameDuplicate": "An account with this name already exists.",
+        "lastAccount": "You cannot remove the last account.",
         "watchOnlySeed": "Watch-only accounts do not have a seed.",
         "watchOnlyRequired": "Name and identity are required.",
         "watchOnlyInvalid": "Identity format is invalid.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -222,7 +222,7 @@
         "passphraseRequired": "Se requiere contraseña.",
         "invalidPassphrase": "Contraseña invalida.",
         "nameDuplicate": "Ya existe una cuenta con este nombre.",
-        "lastAccount": "No puedes eliminar la ultima cuenta.",
+        "lastAccount": "No puedes eliminar la última cuenta.",
         "watchOnlySeed": "Las cuentas de solo lectura no tienen semilla.",
         "watchOnlyRequired": "Se requiere nombre e identidad.",
         "watchOnlyInvalid": "Formato de identidad invalido.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -222,6 +222,7 @@
         "passphraseRequired": "Se requiere contraseña.",
         "invalidPassphrase": "Contraseña invalida.",
         "nameDuplicate": "Ya existe una cuenta con este nombre.",
+        "lastAccount": "No puedes eliminar la ultima cuenta.",
         "watchOnlySeed": "Las cuentas de solo lectura no tienen semilla.",
         "watchOnlyRequired": "Se requiere nombre e identidad.",
         "watchOnlyInvalid": "Formato de identidad invalido.",

--- a/src/pages/manage-accounts.tsx
+++ b/src/pages/manage-accounts.tsx
@@ -164,6 +164,8 @@ const ManageAccounts = () => {
     return map
   }, [balanceQueries, orderedAccounts])
 
+  const canRemoveAnyAccount = orderedAccounts.length > 1
+
   const loadAccounts = async (passphrase: string) => {
     setStatus(null)
     setLoading(true)
@@ -241,6 +243,11 @@ const ManageAccounts = () => {
   }
 
   const handleRemove = async (account: AccountEntry, passphrase: string) => {
+    if (orderedAccounts.length <= 1) {
+      setStatus(t('accounts.manage.errors.lastAccount'))
+      return
+    }
+
     setStatus(null)
     setLoading(true)
     try {
@@ -486,6 +493,7 @@ const ManageAccounts = () => {
                       <DropdownMenuSeparator />
                       <DropdownMenuItem
                         variant="destructive"
+                        disabled={!canRemoveAnyAccount}
                         onClick={() => setRemoveTarget(account)}
                       >
                         <TrashIcon className="h-4 w-4" />
@@ -668,10 +676,16 @@ const ManageAccounts = () => {
             <DrawerTitle>{t('accounts.manage.removeTitle')}</DrawerTitle>
             <DrawerDescription>{t('accounts.manage.removeDesc')}</DrawerDescription>
           </DrawerHeader>
+          {!canRemoveAnyAccount && (
+            <p className="px-4 text-xs text-destructive">
+              {t('accounts.manage.errors.lastAccount')}
+            </p>
+          )}
           <DrawerFooter>
             <Button
               variant="destructive-outline"
               className="w-full"
+              disabled={!canRemoveAnyAccount}
               onClick={() => {
                 if (removeTarget) {
                   if (removeTarget.watchOnly) {


### PR DESCRIPTION
- Prevent removing the last remaining account in Manage Accounts.
- Disable the remove action when only one account exists.
- Show a clear validation/error message for this case.
- Added locale strings for EN/ES.