### PR TITLE
fix: transfer screen UX improvements

### DIFF
--- a/src/components/pages/transfer/confirmation-drawer.tsx
+++ b/src/components/pages/transfer/confirmation-drawer.tsx
@@ -44,6 +44,10 @@ const ConfirmationDrawer = ({
         <DrawerHeader>
           <DrawerTitle>{t('transfer.confirm.title')}</DrawerTitle>
           <DrawerDescription>{t('transfer.confirm.description')}</DrawerDescription>
+          <div className="mt-2 flex items-start gap-2 text-xs text-amber-700 dark:text-amber-300">
+            <AlertTriangleIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+            <span>{t('transfer.confirm.warning')}</span>
+          </div>
         </DrawerHeader>
 
         <div className="flex-1 space-y-4 overflow-y-auto px-4 pb-2">
@@ -58,11 +62,6 @@ const ConfirmationDrawer = ({
             {tokenName !== 'QU' && (
               <SummaryRow label={t('transfer.confirm.feeLabel')} value="100 QU" />
             )}
-          </div>
-
-          <div className="flex items-start gap-2 border-t border-border/40 pt-3 text-xs text-amber-700 dark:text-amber-300">
-            <AlertTriangleIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-            <span>{t('transfer.confirm.warning')}</span>
           </div>
         </div>
 

--- a/src/components/pages/transfer/transfer-form.tsx
+++ b/src/components/pages/transfer/transfer-form.tsx
@@ -318,7 +318,7 @@ const TransferForm = ({
                 />
                 <div className="text-[11px] text-muted-foreground">
                   {t('transfer.form.targetTickCurrentHint', {
-                    tick: typeof currentTick === 'number' ? currentTick : '--',
+                    tick: typeof currentTick === 'number' ? currentTick.toLocaleString() : '--',
                   })}
                 </div>
               </div>

--- a/src/components/pages/transfer/transfer-form.tsx
+++ b/src/components/pages/transfer/transfer-form.tsx
@@ -4,24 +4,15 @@ import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select'
 import { type AggregatedAsset, formatAssetUnits } from '@/lib/assets'
 import { formatBalance, truncateString } from '@/lib/utils'
-import type { FormErrors, SourceAccount } from '@/components/pages/transfer/types'
+import type { FormErrors } from '@/components/pages/transfer/types'
 
 type TransferFormProps = {
   recipient: string
   amount: string
   errors: FormErrors
   errorMessage: string
-  currentIdentity: string
-  fromAccounts: SourceAccount[]
   isWatchOnly: boolean
   assets: AggregatedAsset[]
   vaultRecipients: Array<{ name: string; identity: string }>
@@ -33,7 +24,6 @@ type TransferFormProps = {
   currentTick?: number
   hasPendingOutgoing: boolean
   onTokenChange: (value: string) => void
-  onFromAccountChange: (identity: string) => void
   onSelectVaultRecipient: (identity: string) => void
   onRecipientChange: (value: string) => void
   onAmountChange: (value: string) => void
@@ -51,8 +41,6 @@ const TransferForm = ({
   amount,
   errors,
   errorMessage,
-  currentIdentity,
-  fromAccounts,
   isWatchOnly,
   assets,
   vaultRecipients,
@@ -66,7 +54,6 @@ const TransferForm = ({
   currentTick,
   hasPendingOutgoing,
   onTokenChange,
-  onFromAccountChange,
   onSelectVaultRecipient,
   onRecipientChange,
   onAmountChange,
@@ -199,33 +186,6 @@ const TransferForm = ({
             </span>
           </div>
           {errors.amount && <p className="text-xs text-destructive">{errors.amount}</p>}
-
-          <div className="space-y-2 border-t border-border/40 pt-4">
-            <div className="flex items-center justify-between gap-2">
-              <Label>{t('transfer.form.from')}</Label>
-              {isWatchOnly && (
-                <span className="rounded-full border border-border/60 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground">
-                  {t('transfer.form.watchOnly')}
-                </span>
-              )}
-            </div>
-            <Select value={currentIdentity} onValueChange={onFromAccountChange}>
-              <SelectTrigger className="w-full">
-                <SelectValue placeholder={t('transfer.form.fromPlaceholder')} />
-              </SelectTrigger>
-              <SelectContent>
-                {fromAccounts.map((account) => (
-                  <SelectItem
-                    key={`${account.identity}-${account.watchOnly ? 'watch' : 'vault'}`}
-                    value={account.identity}
-                  >
-                    {account.name} — {truncateString(account.identity)}{' '}
-                    {account.watchOnly ? `(${t('transfer.form.watchOnly')})` : ''}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
 
           <div className="space-y-2 border-t border-border/40 pt-4">
             <Label htmlFor="recipient">{t('transfer.form.recipient')}</Label>

--- a/src/components/pages/transfer/transfer-success.tsx
+++ b/src/components/pages/transfer/transfer-success.tsx
@@ -53,7 +53,9 @@ const TransferSuccess = ({
           <div>
             <h2 className="text-2xl font-semibold">{t('transfer.success.title')}</h2>
             <p className="mt-2 text-sm text-muted-foreground">
-              {t('transfer.success.description', { targetTick: txResult.targetTick })}
+              {t('transfer.success.description', {
+                targetTick: Number(txResult.targetTick).toLocaleString(),
+              })}
             </p>
           </div>
 
@@ -65,7 +67,11 @@ const TransferSuccess = ({
               value={`${formatBalance(txResult.amount)} ${txResult.tokenName}`}
               emphasize
             />
-            <SummaryRow label={t('transfer.success.targetTick')} value={txResult.targetTick} mono />
+            <SummaryRow
+              label={t('transfer.success.targetTick')}
+              value={Number(txResult.targetTick).toLocaleString()}
+              mono
+            />
             {txResult.fee > 0n && (
               <SummaryRow
                 label={t('transfer.confirm.fee', { fee: '100' })}

--- a/src/components/pages/transfer/types.ts
+++ b/src/components/pages/transfer/types.ts
@@ -13,9 +13,3 @@ export type TxResult = {
   recipient: string
   fee: bigint
 }
-
-export type SourceAccount = {
-  name: string
-  identity: string
-  watchOnly?: boolean
-}

--- a/src/pages/passphrase-auth.tsx
+++ b/src/pages/passphrase-auth.tsx
@@ -12,10 +12,9 @@ import {
   DrawerTitle,
 } from '@/components/ui/drawer'
 import { PasswordInput } from '@/components/ui/password-input'
-import { getCurrentVaultIdentity } from '@/lib/accounts'
+
 import { setUnlocked } from '@/lib/lock'
 import { openBrowserVault, verifyVaultAccess } from '@/lib/vault'
-import { truncateString } from '@/lib/utils'
 
 type PassphraseAuthProps = {
   open?: boolean
@@ -35,8 +34,6 @@ const PassphraseAuth = ({
   onCancel,
 }: PassphraseAuthProps) => {
   const { t } = useTranslation()
-  const currentIdentity = identity ?? getCurrentVaultIdentity()
-
   const [passphrase, setPassphrase] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
@@ -119,11 +116,6 @@ const PassphraseAuth = ({
           </div>
           <DrawerTitle>{title ?? t('passphraseAuth.title')}</DrawerTitle>
           <DrawerDescription>{subtitle ?? t('passphraseAuth.subtitle')}</DrawerDescription>
-          {currentIdentity && (
-            <div className="font-mono text-[11px] text-muted-foreground">
-              {truncateString(currentIdentity)}
-            </div>
-          )}
         </DrawerHeader>
 
         <div className="space-y-3 px-4 pb-2">

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -5,12 +5,7 @@ import { toast } from 'sonner'
 import { useBalance, useSdk, useSend } from '@qubic-labs/react'
 import { isValidIdentity, normalizeBalance, parseAmount } from '@/lib/utils'
 import PassphraseAuth from '@/pages/passphrase-auth'
-import {
-  getCachedAccounts,
-  getCurrentIdentity,
-  getWatchOnlyAccounts,
-  isWatchOnlyIdentity,
-} from '@/lib/accounts'
+import { getCachedAccounts, getCurrentIdentity, isWatchOnlyIdentity } from '@/lib/accounts'
 import { aggregateAssets, useOwnedAssets } from '@/lib/assets'
 import {
   QX_ADDRESS,
@@ -25,12 +20,11 @@ import {
   PENDING_SETTLED_EVENT,
   usePendingTransactionsVersion,
 } from '@/lib/pending-transactions'
-import { setOnboarded } from '@/lib/vault'
 import { useLatestStats } from '@/lib/network-stats'
 import ConfirmationDrawer from '@/components/pages/transfer/confirmation-drawer'
 import TransferForm from '@/components/pages/transfer/transfer-form'
 import TransferSuccess from '@/components/pages/transfer/transfer-success'
-import type { FormErrors, SourceAccount, TxResult } from '@/components/pages/transfer/types'
+import type { FormErrors, TxResult } from '@/components/pages/transfer/types'
 
 type Step = 'form' | 'auth' | 'success'
 
@@ -45,30 +39,12 @@ const formatUsd = (value: number) =>
     maximumFractionDigits: 2,
   }).format(value)
 
-const getSourceAccounts = (): SourceAccount[] => {
-  const cached = getCachedAccounts().map((entry) => ({
-    name: entry.name,
-    identity: entry.identity,
-    watchOnly: false,
-  }))
-  const watchOnly = getWatchOnlyAccounts().map((entry) => ({
-    name: entry.name,
-    identity: entry.identity,
-    watchOnly: true,
-  }))
-  return [...cached, ...watchOnly].filter(
-    (entry, index, list) =>
-      list.findIndex((candidate) => candidate.identity === entry.identity) === index,
-  )
-}
-
 const Transfer = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
   usePendingTransactionsVersion()
   const [currentIdentity, setCurrentIdentity] = useState(getCurrentIdentity())
   const [isWatchOnly, setIsWatchOnly] = useState(() => isWatchOnlyIdentity(getCurrentIdentity()))
-  const [fromAccounts, setFromAccounts] = useState<SourceAccount[]>(() => getSourceAccounts())
   const [vaultRecipients, setVaultRecipients] = useState(() => getCachedAccounts())
 
   const sdk = useSdk()
@@ -127,28 +103,10 @@ const Transfer = () => {
     setErrors({})
   }
 
-  const handleFromAccountChange = (identity: string) => {
-    const selectedFrom = fromAccounts.find((entry) => entry.identity === identity)
-    if (!selectedFrom) return
-
-    setCurrentIdentity(identity)
-    setIsWatchOnly(Boolean(selectedFrom.watchOnly))
-    setErrorMessage('')
-    setErrors({})
-    if (recipient.trim() === identity) {
-      setRecipient('')
-    }
-    setAmount('')
-    setSelectedToken('qu')
-    setOnboarded(identity, selectedFrom.name)
-  }
-
   useEffect(() => {
     const refreshAccount = () => {
       const nextIdentity = getCurrentIdentity()
-      const nextAccounts = getSourceAccounts()
       setCurrentIdentity(nextIdentity)
-      setFromAccounts(nextAccounts)
       setIsWatchOnly(isWatchOnlyIdentity(nextIdentity))
       setVaultRecipients(getCachedAccounts())
     }
@@ -365,7 +323,7 @@ const Transfer = () => {
 
       toast.success(t('transfer.success.title'), {
         description: t('transfer.success.description', {
-          targetTick: result.targetTick.toString(),
+          targetTick: Number(result.targetTick).toLocaleString(),
         }),
       })
 
@@ -487,8 +445,6 @@ const Transfer = () => {
         amount={amount}
         errors={errors}
         errorMessage={errorMessage}
-        currentIdentity={currentIdentity}
-        fromAccounts={fromAccounts}
         isWatchOnly={isWatchOnly}
         assets={parsedAssets}
         vaultRecipients={filteredVaultRecipients}
@@ -501,7 +457,6 @@ const Transfer = () => {
         hasPendingOutgoing={hasPendingOutgoing}
         usdEstimate={usdEstimate}
         onTokenChange={handleTokenChange}
-        onFromAccountChange={handleFromAccountChange}
         onSelectVaultRecipient={handleSelectVaultRecipient}
         onRecipientChange={handleRecipientChange}
         onAmountChange={handleAmountChange}


### PR DESCRIPTION
- Format target tick with thousand separators for readability
- Move "cannot be undone" warning below title in confirmation drawer for visibility
- Remove identity display from passphrase authentication screen
- Remove from account selector — always uses the active account