### PR TITLE
fix(pending): prevent pending transactions from being resolved prematurely

### DIFF
--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -160,8 +160,8 @@ const History = () => {
   }
 
   useEffect(() => {
-    resolvePendingTransactions(sorted, currentTick)
-  }, [sorted, currentTick])
+    resolvePendingTransactions(items, currentTick)
+  }, [items, currentTick])
 
   useEffect(() => {
     const handlePendingSettled = () => {

--- a/src/pages/transaction-details.tsx
+++ b/src/pages/transaction-details.tsx
@@ -90,9 +90,9 @@ const TransactionDetails = () => {
     refetchInterval: isPending ? 5_000 : false,
   })
   useEffect(() => {
-    if (!hash) return
+    if (!hash || !txQuery.data) return
     resolvePendingTransactions([{ hash }], currentTick)
-  }, [hash, currentTick])
+  }, [hash, currentTick, txQuery.data])
 
   const details = txQuery.data as Record<string, unknown> | undefined
 


### PR DESCRIPTION
…urely

## Summary
- History page was passing the combined list (pending + API items) to `resolvePendingTransactions`, causing pending transactions to match against themselves and be deleted instantly.
- Transaction details page was resolving pending transactions on mount regardless of whether the API had returned data, so navigating to a pending TX's details and going back would clear the pending state.

## Related
A follow-up issue should be opened to handle transactions that were never added to the tickchain (using `validForTick` from the API to detect and show them as failed).