### PR TITLE
fix(pending): handle never-confirmed transactions as failed with resend/delete flow

### DIFF
--- a/src/components/pages/home/transactions-preview.tsx
+++ b/src/components/pages/home/transactions-preview.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { InboxIcon } from 'lucide-react'
+import { InboxIcon, XIcon } from 'lucide-react'
 import type { useTransactions } from '@qubic-labs/react'
 import { motion } from 'framer-motion'
 import { useTranslation } from 'react-i18next'
@@ -10,6 +10,7 @@ import {
   type PendingTransaction,
   isTransactionFailed,
   isTransactionPending,
+  removePendingTransaction,
 } from '@/lib/pending-transactions'
 
 type PreviewTransaction = {
@@ -29,7 +30,7 @@ type TransactionsPreviewProps = {
   pendingTransactions: PendingTransaction[]
   onViewMore: () => void
   onOpenTx: (hash: string) => void
-  onResend: (recipient: string, amount: bigint) => void
+  onResend: (failedHash: string, recipient: string, amount: bigint) => void
 }
 
 const TransactionsPreview = ({
@@ -97,7 +98,7 @@ const TransactionsPreview = ({
         }`}
         onClick={() => {
           if (tx.status === 'failed') {
-            onResend(tx.destination, tx.amount)
+            onResend(tx.hash, tx.destination, tx.amount)
             return
           }
           onOpenTx(tx.hash)
@@ -155,9 +156,23 @@ const TransactionsPreview = ({
           {formatBalanceCompact(tx.amount)}
         </span>
         {isFailed && (
-          <span className="ml-2 text-[11px] font-semibold uppercase tracking-wide text-primary">
-            {t('history.resend')}
-          </span>
+          <div className="ml-2 flex items-center gap-1">
+            <span className="text-[11px] font-semibold uppercase tracking-wide text-primary">
+              {t('history.resend')}
+            </span>
+            <button
+              type="button"
+              className="cursor-pointer text-muted-foreground transition-colors hover:text-foreground"
+              onClick={(event) => {
+                event.stopPropagation()
+                removePendingTransaction(tx.hash)
+              }}
+              aria-label={t('history.deleteFailed')}
+              title={t('history.deleteFailed')}
+            >
+              <XIcon className="h-3.5 w-3.5" />
+            </button>
+          </div>
         )}
       </motion.button>
     )
@@ -207,6 +222,11 @@ const TransactionsPreview = ({
             {t('history.failed')}
           </div>
           {failedTop.map((tx) => renderRow(tx))}
+        </div>
+      )}
+      {(pendingTop.length > 0 || failedTop.length > 0) && recentChain.length > 0 && (
+        <div className="pt-1">
+          <div className="h-px w-full bg-border/40" />
         </div>
       )}
       {recentChain.map((tx) => renderRow(tx))}

--- a/src/components/pages/home/transactions-preview.tsx
+++ b/src/components/pages/home/transactions-preview.tsx
@@ -7,34 +7,44 @@ import { formatBalanceCompact, truncateString } from '@/lib/utils'
 import { ReceiveIcon } from '@/components/icons/receive-icon'
 import { SendIcon } from '@/components/icons/send-icon'
 import {
-  getPendingTransactionsForIdentity,
+  type PendingTransaction,
+  isTransactionFailed,
   isTransactionPending,
-  usePendingTransactionsVersion,
 } from '@/lib/pending-transactions'
+
+type PreviewTransaction = {
+  hash: string
+  source: string
+  destination: string
+  amount: bigint
+  tickNumber: number | bigint
+  inputType: number | bigint
+  timestamp: bigint
+  status?: PendingTransaction['status']
+}
 
 type TransactionsPreviewProps = {
   identity: string
   transactions: ReturnType<typeof useTransactions>
-  currentTick?: number
+  pendingTransactions: PendingTransaction[]
   onViewMore: () => void
   onOpenTx: (hash: string) => void
+  onResend: (recipient: string, amount: bigint) => void
 }
 
 const TransactionsPreview = ({
   identity,
   transactions,
-  currentTick,
+  pendingTransactions,
   onViewMore,
   onOpenTx,
+  onResend,
 }: TransactionsPreviewProps) => {
   const { t } = useTranslation()
-  usePendingTransactionsVersion()
 
-  const recent = useMemo(() => {
+  const { pendingTop, failedTop, recentChain } = useMemo(() => {
     const items = transactions.data?.pages.flatMap((page) => page.transactions) ?? []
-    const pending = getPendingTransactionsForIdentity(identity, currentTick)
-    const pendingHashes = new Set(pending.map((tx) => tx.hash.toLowerCase()))
-    const pendingItems = pending.map((tx) => ({
+    const pendingItems: PreviewTransaction[] = pendingTransactions.map((tx) => ({
       hash: tx.hash,
       source: tx.sourceIdentity,
       destination: tx.destinationIdentity ?? '',
@@ -42,13 +52,116 @@ const TransactionsPreview = ({
       tickNumber: tx.targetTick,
       inputType: tx.inputType ?? 0,
       timestamp: BigInt(tx.createdAt),
+      status: tx.status,
     }))
-    const merged = [
-      ...pendingItems,
-      ...items.filter((tx) => !pendingHashes.has(tx.hash.toLowerCase())),
-    ]
-    return merged.slice(0, 3)
-  }, [transactions.data, identity, currentTick])
+    const pendingHashes = new Set(pendingItems.map((tx) => tx.hash.toLowerCase()))
+    const pendingTop = pendingItems.filter((tx) => tx.status === 'pending')
+    const failedTop = pendingItems.filter((tx) => tx.status === 'failed')
+    const recentChain: PreviewTransaction[] = items
+      .filter((tx) => !pendingHashes.has(tx.hash.toLowerCase()))
+      .slice(0, 3)
+
+    return { pendingTop, failedTop, recentChain }
+  }, [transactions.data, pendingTransactions])
+
+  const renderRow = (tx: PreviewTransaction) => {
+    const isIncoming = tx.destination === identity
+    const isSimpleTransfer = Number(tx.inputType) === 0
+    const label = isSimpleTransfer
+      ? isIncoming
+        ? t('history.received')
+        : t('history.sent')
+      : isIncoming
+        ? t('history.incoming')
+        : t('history.outgoing')
+    const counterparty = isIncoming ? tx.source : tx.destination
+    const counterpartyLabel = isSimpleTransfer
+      ? isIncoming
+        ? t('history.from', { address: truncateString(counterparty) })
+        : t('history.to', { address: truncateString(counterparty) })
+      : truncateString(counterparty)
+    const Icon = isIncoming ? ReceiveIcon : SendIcon
+    const isPending = isTransactionPending(tx.hash)
+    const isFailed = isTransactionFailed(tx.hash)
+
+    return (
+      <motion.button
+        type="button"
+        key={tx.hash}
+        className={`group flex w-full cursor-pointer items-center justify-between rounded-xl border px-3 py-2 text-left transition-colors ${
+          isPending
+            ? 'animate-pulse border-amber-500/50 bg-amber-500/10 text-amber-800 dark:text-amber-200'
+            : isFailed
+              ? 'border-red-500/50 bg-red-500/10 text-red-800 dark:text-red-200'
+              : 'border-border/40 bg-background/40 hover:border-primary/30 hover:bg-background/60'
+        }`}
+        onClick={() => {
+          if (tx.status === 'failed') {
+            onResend(tx.destination, tx.amount)
+            return
+          }
+          onOpenTx(tx.hash)
+        }}
+      >
+        <div className="flex items-center gap-3">
+          <div
+            className={`flex h-9 w-9 items-center justify-center rounded-full border ${
+              isPending
+                ? 'border-amber-500/40 bg-amber-500/15 text-amber-700 dark:text-amber-300'
+                : isFailed
+                  ? 'border-red-500/40 bg-red-500/15 text-red-700 dark:text-red-300'
+                  : isIncoming
+                    ? 'border-primary/40 bg-primary/10 text-primary'
+                    : 'border-[var(--destructive)]/40 bg-[var(--destructive)]/10 text-[var(--destructive)]'
+            }`}
+          >
+            <Icon className="h-4 w-4" />
+          </div>
+          <div className="flex flex-col">
+            <span className="text-xs font-semibold text-foreground">{label}</span>
+            <span className="text-xs text-muted-foreground">{counterpartyLabel}</span>
+            <span className="text-[11px] text-muted-foreground/70">
+              {(() => {
+                if (isFailed) return t('history.failed')
+                const ts = Number(tx.timestamp)
+                if (!ts) return '--'
+                const date = new Date(ts > 1e12 ? ts : ts * 1000)
+                const now = new Date()
+                if (date.toDateString() === now.toDateString()) return t('history.today')
+                const yesterday = new Date(now)
+                yesterday.setDate(yesterday.getDate() - 1)
+                if (date.toDateString() === yesterday.toDateString()) return t('history.yesterday')
+                return date.toLocaleDateString(undefined, {
+                  month: 'short',
+                  day: 'numeric',
+                  year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
+                })
+              })()}
+            </span>
+          </div>
+        </div>
+        <span
+          className={`text-sm font-semibold ${
+            isPending
+              ? 'text-amber-700 dark:text-amber-300'
+              : isFailed
+                ? 'text-red-700 dark:text-red-300'
+                : isIncoming
+                  ? 'text-primary'
+                  : 'text-[var(--destructive)]'
+          }`}
+        >
+          {isIncoming ? '+' : '-'}
+          {formatBalanceCompact(tx.amount)}
+        </span>
+        {isFailed && (
+          <span className="ml-2 text-[11px] font-semibold uppercase tracking-wide text-primary">
+            {t('history.resend')}
+          </span>
+        )}
+      </motion.button>
+    )
+  }
 
   if (transactions.isLoading) {
     return (
@@ -64,7 +177,7 @@ const TransactionsPreview = ({
     return <div className="text-xs text-destructive">{transactions.error.message}</div>
   }
 
-  if (recent.length === 0) {
+  if (pendingTop.length === 0 && failedTop.length === 0 && recentChain.length === 0) {
     return (
       <div className="flex items-center gap-3 rounded-lg border border-dashed border-border/60 bg-muted/20 px-3 py-3 text-xs text-muted-foreground">
         <div className="flex h-9 w-9 items-center justify-center rounded-full bg-muted/40 text-muted-foreground">
@@ -80,86 +193,23 @@ const TransactionsPreview = ({
 
   return (
     <div className="w-full space-y-2 text-left">
-      {recent.map((tx) => {
-        const isIncoming = tx.destination === identity
-        const isSimpleTransfer = Number(tx.inputType) === 0
-        const label = isSimpleTransfer
-          ? isIncoming
-            ? t('history.received')
-            : t('history.sent')
-          : isIncoming
-            ? t('history.incoming')
-            : t('history.outgoing')
-        const counterparty = isIncoming ? tx.source : tx.destination
-        const counterpartyLabel = isSimpleTransfer
-          ? isIncoming
-            ? t('history.from', { address: truncateString(counterparty) })
-            : t('history.to', { address: truncateString(counterparty) })
-          : truncateString(counterparty)
-        const Icon = isIncoming ? ReceiveIcon : SendIcon
-        const isPending = isTransactionPending(tx.hash, currentTick)
-
-        return (
-          <motion.button
-            type="button"
-            key={tx.hash}
-            className={`group flex w-full cursor-pointer items-center justify-between rounded-xl border px-3 py-2 text-left transition-colors ${
-              isPending
-                ? 'animate-pulse border-amber-500/50 bg-amber-500/10 text-amber-800 dark:text-amber-200'
-                : 'border-border/40 bg-background/40 hover:border-primary/30 hover:bg-background/60'
-            }`}
-            onClick={() => onOpenTx(tx.hash)}
-          >
-            <div className="flex items-center gap-3">
-              <div
-                className={`flex h-9 w-9 items-center justify-center rounded-full border ${
-                  isPending
-                    ? 'border-amber-500/40 bg-amber-500/15 text-amber-700 dark:text-amber-300'
-                    : isIncoming
-                      ? 'border-primary/40 bg-primary/10 text-primary'
-                      : 'border-[var(--destructive)]/40 bg-[var(--destructive)]/10 text-[var(--destructive)]'
-                }`}
-              >
-                <Icon className="h-4 w-4" />
-              </div>
-              <div className="flex flex-col">
-                <span className="text-xs font-semibold text-foreground">{label}</span>
-                <span className="text-xs text-muted-foreground">{counterpartyLabel}</span>
-                <span className="text-[11px] text-muted-foreground/70">
-                  {(() => {
-                    const ts = Number(tx.timestamp)
-                    if (!ts) return '--'
-                    const date = new Date(ts > 1e12 ? ts : ts * 1000)
-                    const now = new Date()
-                    if (date.toDateString() === now.toDateString()) return t('history.today')
-                    const yesterday = new Date(now)
-                    yesterday.setDate(yesterday.getDate() - 1)
-                    if (date.toDateString() === yesterday.toDateString())
-                      return t('history.yesterday')
-                    return date.toLocaleDateString(undefined, {
-                      month: 'short',
-                      day: 'numeric',
-                      year: date.getFullYear() !== now.getFullYear() ? 'numeric' : undefined,
-                    })
-                  })()}
-                </span>
-              </div>
-            </div>
-            <span
-              className={`text-sm font-semibold ${
-                isPending
-                  ? 'text-amber-700 dark:text-amber-300'
-                  : isIncoming
-                    ? 'text-primary'
-                    : 'text-[var(--destructive)]'
-              }`}
-            >
-              {isIncoming ? '+' : '-'}
-              {formatBalanceCompact(tx.amount)}
-            </span>
-          </motion.button>
-        )
-      })}
+      {pendingTop.length > 0 && (
+        <div className="space-y-2">
+          <div className="text-[11px] font-semibold uppercase text-muted-foreground/70">
+            {t('history.pending')}
+          </div>
+          {pendingTop.map((tx) => renderRow(tx))}
+        </div>
+      )}
+      {failedTop.length > 0 && (
+        <div className="space-y-2">
+          <div className="text-[11px] font-semibold uppercase text-muted-foreground/70">
+            {t('history.failed')}
+          </div>
+          {failedTop.map((tx) => renderRow(tx))}
+        </div>
+      )}
+      {recentChain.map((tx) => renderRow(tx))}
       <button
         type="button"
         className="w-full cursor-pointer pt-1 text-center text-xs text-muted-foreground transition-colors hover:text-foreground"

--- a/src/components/pages/home/transactions-preview.tsx
+++ b/src/components/pages/home/transactions-preview.tsx
@@ -32,13 +32,7 @@ type TransactionsPreviewProps = {
   pendingTransactions: PendingTransaction[]
   onViewMore: () => void
   onOpenTx: (hash: string) => void
-  onResend: (
-    failedHash: string,
-    recipient: string,
-    amount: bigint,
-    inputType: number,
-    tokenKey?: string,
-  ) => void
+  onResend: (failedHash: string, recipient: string, amount: bigint, tokenKey?: string) => void
 }
 
 const TransactionsPreview = ({
@@ -168,9 +162,7 @@ const TransactionsPreview = ({
               <button
                 type="button"
                 className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-primary hover:underline"
-                onClick={() =>
-                  onResend(tx.hash, tx.destination, tx.amount, Number(tx.inputType), tx.tokenKey)
-                }
+                onClick={() => onResend(tx.hash, tx.destination, tx.amount, tx.tokenKey)}
               >
                 {t('history.resend')}
               </button>

--- a/src/components/pages/home/transactions-preview.tsx
+++ b/src/components/pages/home/transactions-preview.tsx
@@ -30,7 +30,7 @@ type TransactionsPreviewProps = {
   pendingTransactions: PendingTransaction[]
   onViewMore: () => void
   onOpenTx: (hash: string) => void
-  onResend: (failedHash: string, recipient: string, amount: bigint) => void
+  onResend: (failedHash: string, recipient: string, amount: bigint, inputType: number) => void
 }
 
 const TransactionsPreview = ({
@@ -84,25 +84,18 @@ const TransactionsPreview = ({
     const Icon = isIncoming ? ReceiveIcon : SendIcon
     const isPending = isTransactionPending(tx.hash)
     const isFailed = isTransactionFailed(tx.hash)
+    const canResend = isFailed && Number(tx.inputType) === 0 && Boolean(tx.destination)
 
     return (
-      <motion.button
-        type="button"
+      <motion.div
         key={tx.hash}
-        className={`group flex w-full cursor-pointer items-center justify-between rounded-xl border px-3 py-2 text-left transition-colors ${
+        className={`group relative flex w-full items-center justify-between rounded-xl border px-3 py-2 text-left transition-colors ${
           isPending
             ? 'animate-pulse border-amber-500/50 bg-amber-500/10 text-amber-800 dark:text-amber-200'
             : isFailed
               ? 'border-red-500/50 bg-red-500/10 text-red-800 dark:text-red-200'
               : 'border-border/40 bg-background/40 hover:border-primary/30 hover:bg-background/60'
         }`}
-        onClick={() => {
-          if (tx.status === 'failed') {
-            onResend(tx.hash, tx.destination, tx.amount)
-            return
-          }
-          onOpenTx(tx.hash)
-        }}
       >
         <div className="flex items-center gap-3">
           <div
@@ -157,16 +150,19 @@ const TransactionsPreview = ({
         </span>
         {isFailed && (
           <div className="ml-2 flex items-center gap-1">
-            <span className="text-[11px] font-semibold uppercase tracking-wide text-primary">
-              {t('history.resend')}
-            </span>
+            {canResend && (
+              <button
+                type="button"
+                className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-primary hover:underline"
+                onClick={() => onResend(tx.hash, tx.destination, tx.amount, Number(tx.inputType))}
+              >
+                {t('history.resend')}
+              </button>
+            )}
             <button
               type="button"
               className="cursor-pointer text-muted-foreground transition-colors hover:text-foreground"
-              onClick={(event) => {
-                event.stopPropagation()
-                removePendingTransaction(tx.hash)
-              }}
+              onClick={() => removePendingTransaction(tx.hash)}
               aria-label={t('history.deleteFailed')}
               title={t('history.deleteFailed')}
             >
@@ -174,7 +170,15 @@ const TransactionsPreview = ({
             </button>
           </div>
         )}
-      </motion.button>
+        {!isFailed && (
+          <button
+            type="button"
+            className="absolute inset-0 cursor-pointer rounded-xl"
+            aria-label={t('txDetails.title')}
+            onClick={() => onOpenTx(tx.hash)}
+          />
+        )}
+      </motion.div>
     )
   }
 

--- a/src/components/pages/home/transactions-preview.tsx
+++ b/src/components/pages/home/transactions-preview.tsx
@@ -7,6 +7,7 @@ import { formatBalanceCompact, truncateString } from '@/lib/utils'
 import { ReceiveIcon } from '@/components/icons/receive-icon'
 import { SendIcon } from '@/components/icons/send-icon'
 import {
+  canResendPendingTransaction,
   type PendingTransaction,
   isTransactionFailed,
   isTransactionPending,
@@ -20,6 +21,7 @@ type PreviewTransaction = {
   amount: bigint
   tickNumber: number | bigint
   inputType: number | bigint
+  tokenKey?: string
   timestamp: bigint
   status?: PendingTransaction['status']
 }
@@ -30,7 +32,13 @@ type TransactionsPreviewProps = {
   pendingTransactions: PendingTransaction[]
   onViewMore: () => void
   onOpenTx: (hash: string) => void
-  onResend: (failedHash: string, recipient: string, amount: bigint, inputType: number) => void
+  onResend: (
+    failedHash: string,
+    recipient: string,
+    amount: bigint,
+    inputType: number,
+    tokenKey?: string,
+  ) => void
 }
 
 const TransactionsPreview = ({
@@ -52,6 +60,7 @@ const TransactionsPreview = ({
       amount: tx.amount ?? 0n,
       tickNumber: tx.targetTick,
       inputType: tx.inputType ?? 0,
+      tokenKey: tx.tokenKey,
       timestamp: BigInt(tx.createdAt),
       status: tx.status,
     }))
@@ -84,7 +93,12 @@ const TransactionsPreview = ({
     const Icon = isIncoming ? ReceiveIcon : SendIcon
     const isPending = isTransactionPending(tx.hash)
     const isFailed = isTransactionFailed(tx.hash)
-    const canResend = isFailed && Number(tx.inputType) === 0 && Boolean(tx.destination)
+    const canResend = canResendPendingTransaction({
+      status: tx.status ?? 'pending',
+      destinationIdentity: tx.destination,
+      inputType: Number(tx.inputType),
+      tokenKey: tx.tokenKey,
+    })
 
     return (
       <motion.div
@@ -154,7 +168,9 @@ const TransactionsPreview = ({
               <button
                 type="button"
                 className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-primary hover:underline"
-                onClick={() => onResend(tx.hash, tx.destination, tx.amount, Number(tx.inputType))}
+                onClick={() =>
+                  onResend(tx.hash, tx.destination, tx.amount, Number(tx.inputType), tx.tokenKey)
+                }
               >
                 {t('history.resend')}
               </button>

--- a/src/components/pages/transfer/transfer-success.tsx
+++ b/src/components/pages/transfer/transfer-success.tsx
@@ -90,7 +90,7 @@ const TransferSuccess = ({
 
         <div className="flex flex-col gap-2">
           <Button onClick={onViewDetails} variant="secondary" size="lg" className="w-full">
-            {t('history.details.title')}
+            {t('txDetails.title')}
           </Button>
           <Button onClick={onViewHistory} variant="outline" size="lg" className="w-full">
             {t('transfer.success.viewHistory')}

--- a/src/lib/pending-transactions.ts
+++ b/src/lib/pending-transactions.ts
@@ -1,4 +1,5 @@
 import { useSyncExternalStore } from 'react'
+import { QX_TRANSFER_ASSET_INPUT_TYPE } from '@/lib/qx'
 
 export type PendingTransactionStatus = 'pending' | 'failed'
 
@@ -9,6 +10,7 @@ export type PendingTransaction = {
   amount?: bigint
   quImpact?: bigint
   inputType?: number
+  tokenKey?: string
   targetTick: number
   createdAt: number
   status: PendingTransactionStatus
@@ -21,6 +23,7 @@ type SerializedPendingTransaction = {
   amount?: string
   quImpact?: string
   inputType?: number
+  tokenKey?: string
   targetTick: number
   createdAt: number
   status?: PendingTransactionStatus
@@ -70,6 +73,7 @@ const toSerialized = (pending: PendingTransaction): SerializedPendingTransaction
   amount: pending.amount?.toString(),
   quImpact: pending.quImpact?.toString(),
   inputType: pending.inputType,
+  tokenKey: pending.tokenKey,
   targetTick: pending.targetTick,
   createdAt: pending.createdAt,
   status: pending.status,
@@ -89,6 +93,7 @@ const fromSerialized = (value: unknown): PendingTransaction | null => {
       amount: data.amount ? BigInt(data.amount) : undefined,
       quImpact: data.quImpact ? BigInt(data.quImpact) : undefined,
       inputType: data.inputType,
+      tokenKey: data.tokenKey,
       targetTick: data.targetTick,
       createdAt: typeof data.createdAt === 'number' ? data.createdAt : Date.now(),
       status: data.status === 'failed' ? 'failed' : 'pending',
@@ -157,6 +162,7 @@ export const addPendingTransaction = (pending: {
   amount?: bigint
   quImpact?: bigint
   inputType?: number
+  tokenKey?: string
   targetTick: number
 }) => {
   const key = normalizeHash(pending.hash)
@@ -220,6 +226,18 @@ export const getPendingOutgoingDebit = (identity: string) => {
     const debit = tx.quImpact ?? tx.amount ?? 0n
     return sum + (debit > 0n ? debit : 0n)
   }, 0n)
+}
+
+export const canResendPendingTransaction = (
+  pending: Pick<PendingTransaction, 'status' | 'destinationIdentity' | 'inputType' | 'tokenKey'>,
+) => {
+  if (pending.status !== 'failed') return false
+  if (!pending.destinationIdentity) return false
+  if (pending.inputType === 0 || pending.inputType === undefined) return true
+  if (pending.inputType === QX_TRANSFER_ASSET_INPUT_TYPE) {
+    return Boolean(pending.tokenKey)
+  }
+  return false
 }
 
 const parseProcessedTick = (value?: number | bigint | null) => {

--- a/src/lib/pending-transactions.ts
+++ b/src/lib/pending-transactions.ts
@@ -1,6 +1,8 @@
 import { useSyncExternalStore } from 'react'
 
-type PendingTransaction = {
+export type PendingTransactionStatus = 'pending' | 'failed'
+
+export type PendingTransaction = {
   hash: string
   sourceIdentity: string
   destinationIdentity?: string
@@ -9,6 +11,7 @@ type PendingTransaction = {
   inputType?: number
   targetTick: number
   createdAt: number
+  status: PendingTransactionStatus
 }
 
 type SerializedPendingTransaction = {
@@ -20,6 +23,7 @@ type SerializedPendingTransaction = {
   inputType?: number
   targetTick: number
   createdAt: number
+  status?: PendingTransactionStatus
 }
 
 const PENDING_STORAGE_KEY = 'wallet:pending-transactions:v1'
@@ -67,6 +71,7 @@ const toSerialized = (pending: PendingTransaction): SerializedPendingTransaction
   inputType: pending.inputType,
   targetTick: pending.targetTick,
   createdAt: pending.createdAt,
+  status: pending.status,
 })
 
 const fromSerialized = (value: unknown): PendingTransaction | null => {
@@ -85,6 +90,7 @@ const fromSerialized = (value: unknown): PendingTransaction | null => {
       inputType: data.inputType,
       targetTick: data.targetTick,
       createdAt: typeof data.createdAt === 'number' ? data.createdAt : Date.now(),
+      status: data.status === 'failed' ? 'failed' : 'pending',
     }
   } catch {
     return null
@@ -153,6 +159,7 @@ export const addPendingTransaction = (pending: {
     ...pending,
     hash: pending.hash,
     createdAt: Date.now(),
+    status: 'pending',
   })
   persistPending()
   notify()
@@ -167,74 +174,83 @@ export const removePendingTransaction = (hash: string) => {
   }
 }
 
-export const isTransactionPending = (hash: string, currentTick?: number) => {
+export const isTransactionPending = (hash: string) => {
   const key = normalizeHash(hash)
   if (!key) return false
   const pending = pendingByHash.get(key)
-  if (!pending) return false
-
-  const isTickReached =
-    typeof currentTick === 'number' &&
-    Number.isFinite(currentTick) &&
-    Number.isFinite(pending.targetTick) &&
-    currentTick >= pending.targetTick
-
-  if (isTickReached) {
-    if (pendingByHash.delete(key)) {
-      schedulePendingSettledEvent(pending)
-      persistPending()
-      notify()
-    }
-    return false
-  }
-
-  return true
+  return Boolean(pending && pending.status === 'pending')
 }
 
-export const getPendingTransaction = (hash: string, currentTick?: number) => {
-  if (!isTransactionPending(hash, currentTick)) return null
-  return pendingByHash.get(normalizeHash(hash)) ?? null
+export const isTransactionFailed = (hash: string) => {
+  const key = normalizeHash(hash)
+  if (!key) return false
+  const pending = pendingByHash.get(key)
+  return Boolean(pending && pending.status === 'failed')
 }
 
-export const getPendingTransactionsForIdentity = (identity: string, currentTick?: number) => {
+export const getPendingTransaction = (hash: string) => {
+  const key = normalizeHash(hash)
+  if (!key) return null
+  return pendingByHash.get(key) ?? null
+}
+
+export const getPendingTransactionsForIdentity = (identity: string) => {
   if (!identity) return []
   const items: PendingTransaction[] = []
   for (const pending of pendingByHash.values()) {
     if (pending.sourceIdentity !== identity) continue
-    if (!isTransactionPending(pending.hash, currentTick)) continue
     items.push(pending)
   }
-  return items.sort((a, b) => b.createdAt - a.createdAt)
+  return items.sort((a, b) => {
+    if (a.status === b.status) return b.createdAt - a.createdAt
+    return a.status === 'pending' ? -1 : 1
+  })
 }
 
-export const getPendingOutgoingDebit = (identity: string, currentTick?: number) => {
-  const pending = getPendingTransactionsForIdentity(identity, currentTick)
+export const getPendingOutgoingDebit = (identity: string) => {
+  const pending = getPendingTransactionsForIdentity(identity)
   return pending.reduce((sum, tx) => {
+    if (tx.status !== 'pending') return sum
     const debit = tx.quImpact ?? tx.amount ?? 0n
     return sum + (debit > 0n ? debit : 0n)
   }, 0n)
 }
 
+const parseProcessedTick = (value?: number | bigint | null) => {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+  if (typeof value === 'bigint') {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
 export const resolvePendingTransactions = (
   transactions: Array<{ hash: string }>,
-  currentTick?: number,
+  processedTick?: number | bigint,
 ) => {
   if (pendingByHash.size === 0) return
   let changed = false
+  const confirmedHashes = new Set(transactions.map((tx) => normalizeHash(tx.hash)))
 
-  for (const tx of transactions) {
-    const key = normalizeHash(tx.hash)
+  for (const key of confirmedHashes) {
     if (pendingByHash.has(key)) {
-      pendingByHash.delete(key)
-      changed = true
+      const settled = pendingByHash.get(key)
+      if (settled && pendingByHash.delete(key)) {
+        schedulePendingSettledEvent(settled)
+        changed = true
+      }
     }
   }
 
-  if (typeof currentTick === 'number' && Number.isFinite(currentTick)) {
+  const lastProcessedTick = parseProcessedTick(processedTick)
+  if (lastProcessedTick != null) {
     for (const [key, pending] of pendingByHash.entries()) {
-      if (currentTick >= pending.targetTick) {
-        pendingByHash.delete(key)
-        schedulePendingSettledEvent(pending)
+      if (pending.status !== 'pending') continue
+      if (lastProcessedTick > pending.targetTick) {
+        pendingByHash.set(key, { ...pending, status: 'failed' })
         changed = true
       }
     }

--- a/src/lib/pending-transactions.ts
+++ b/src/lib/pending-transactions.ts
@@ -240,6 +240,17 @@ export const canResendPendingTransaction = (
   return false
 }
 
+export const getArchiverProcessedTick = (
+  pages: Array<{ validForTick?: bigint }> | undefined,
+): bigint | undefined => {
+  if (!pages || pages.length === 0) return undefined
+  return pages.reduce<bigint | undefined>((max, page) => {
+    if (typeof page.validForTick !== 'bigint') return max
+    if (max === undefined || page.validForTick > max) return page.validForTick
+    return max
+  }, undefined)
+}
+
 const parseProcessedTick = (value?: number | bigint | null) => {
   if (typeof value === 'number') {
     return Number.isFinite(value) ? value : null

--- a/src/lib/pending-transactions.ts
+++ b/src/lib/pending-transactions.ts
@@ -33,6 +33,7 @@ const PENDING_SETTLED_REFETCH_DELAY_MS = 2_500
 const pendingByHash = new Map<string, PendingTransaction>()
 const listeners = new Set<() => void>()
 const settledEventTimers = new Map<string, number>()
+let pendingVersion = 0
 
 const normalizeHash = (hash: string) => hash.trim().toLowerCase()
 const hasStorage = () => typeof localStorage !== 'undefined'
@@ -130,6 +131,11 @@ const notify = () => {
   })
 }
 
+const notifyPendingChanged = () => {
+  pendingVersion += 1
+  notify()
+}
+
 const subscribe = (listener: () => void) => {
   listeners.add(listener)
   return () => {
@@ -137,7 +143,7 @@ const subscribe = (listener: () => void) => {
   }
 }
 
-const getSnapshot = () => pendingByHash.size
+const getSnapshot = () => pendingVersion
 
 export const usePendingTransactionsVersion = () =>
   useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
@@ -162,7 +168,7 @@ export const addPendingTransaction = (pending: {
     status: 'pending',
   })
   persistPending()
-  notify()
+  notifyPendingChanged()
 }
 
 export const removePendingTransaction = (hash: string) => {
@@ -170,7 +176,7 @@ export const removePendingTransaction = (hash: string) => {
   if (!key) return
   if (pendingByHash.delete(key)) {
     persistPending()
-    notify()
+    notifyPendingChanged()
   }
 }
 
@@ -258,6 +264,6 @@ export const resolvePendingTransactions = (
 
   if (changed) {
     persistPending()
-    notify()
+    notifyPendingChanged()
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -353,7 +353,6 @@
       "broadcastFailed": "Failed to broadcast transaction.",
       "watchOnly": "Watch-only accounts cannot send transfers.",
       "pendingOutgoing": "A previous outgoing transfer is still pending. Please wait for confirmation.",
-      "resendUnsupported": "Resend is currently supported only for simple QU transfers.",
       "generic": "Transfer failed. Please retry."
     }
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -240,6 +240,8 @@
     "tick": "Tick",
     "type": "Type",
     "pending": "Pending",
+    "failed": "Failed",
+    "resend": "Resend",
     "today": "Today",
     "yesterday": "Yesterday"
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -353,6 +353,7 @@
       "broadcastFailed": "Failed to broadcast transaction.",
       "watchOnly": "Watch-only accounts cannot send transfers.",
       "pendingOutgoing": "A previous outgoing transfer is still pending. Please wait for confirmation.",
+      "resendUnsupported": "Resend is currently supported only for simple QU transfers.",
       "generic": "Transfer failed. Please retry."
     }
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -242,6 +242,7 @@
     "pending": "Pending",
     "failed": "Failed",
     "resend": "Resend",
+    "deleteFailed": "Delete failed transaction",
     "today": "Today",
     "yesterday": "Yesterday"
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -353,6 +353,7 @@
       "broadcastFailed": "Fallo al transmitir la transacción.",
       "watchOnly": "Las cuentas de solo lectura no pueden enviar transferencias.",
       "pendingOutgoing": "Hay una transferencia saliente pendiente. Espera su confirmación antes de enviar otra.",
+      "resendUnsupported": "El reenvío por ahora solo es compatible con transferencias simples de QU.",
       "generic": "Transferencia fallida. Intenta de nuevo."
     }
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -353,7 +353,6 @@
       "broadcastFailed": "Fallo al transmitir la transacción.",
       "watchOnly": "Las cuentas de solo lectura no pueden enviar transferencias.",
       "pendingOutgoing": "Hay una transferencia saliente pendiente. Espera su confirmación antes de enviar otra.",
-      "resendUnsupported": "El reenvío por ahora solo es compatible con transferencias simples de QU.",
       "generic": "Transferencia fallida. Intenta de nuevo."
     }
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -240,6 +240,8 @@
     "tick": "Tick",
     "type": "Tipo",
     "pending": "Pendiente",
+    "failed": "Fallida",
+    "resend": "Reenviar",
     "today": "Hoy",
     "yesterday": "Ayer"
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -242,6 +242,7 @@
     "pending": "Pendiente",
     "failed": "Fallida",
     "resend": "Reenviar",
+    "deleteFailed": "Eliminar transacción fallida",
     "today": "Hoy",
     "yesterday": "Ayer"
   },

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useNavigate } from 'react-router-dom'
 import {
+  canResendPendingTransaction,
   getPendingTransactionsForIdentity,
   PENDING_SETTLED_EVENT,
   removePendingTransaction,
@@ -45,7 +46,10 @@ type HistoryRowTransaction = {
   amount: bigint
   tickNumber: number | bigint
   inputType: number | bigint
+  tokenKey?: string
 }
+
+type HistoryRowState = 'default' | 'pending' | 'failed'
 
 const History = () => {
   const { t } = useTranslation()
@@ -106,6 +110,7 @@ const History = () => {
         amount: tx.amount ?? 0n,
         tickNumber: tx.targetTick,
         inputType: tx.inputType ?? 0,
+        tokenKey: tx.tokenKey,
         timestamp: BigInt(tx.createdAt),
         status: tx.status,
       })),
@@ -203,6 +208,97 @@ const History = () => {
     const Icon = isIncoming ? ReceiveIcon : SendIcon
 
     return { isIncoming, label, counterpartyLabel, Icon }
+  }
+
+  const renderHistoryRow = (tx: HistoryRowTransaction, state: HistoryRowState) => {
+    const { isIncoming, label, counterpartyLabel, Icon } = getRowPresentation(tx)
+    const isPending = state === 'pending'
+    const isDefault = state === 'default'
+
+    return (
+      <motion.button
+        type="button"
+        key={tx.hash}
+        className={`w-full cursor-pointer space-y-3 rounded-xl border px-3 py-3 text-left transition-colors ${
+          isPending
+            ? 'border-amber-500/50 bg-amber-500/10'
+            : 'border-border/40 bg-background/40 hover:border-primary/30 hover:bg-background/60'
+        }`}
+        onClick={() => navigate(`/tx/${tx.hash}`)}
+        variants={itemMotion}
+      >
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <div
+              className={`flex h-9 w-9 items-center justify-center rounded-full border ${
+                isPending
+                  ? 'border-amber-500/40 bg-amber-500/15 text-amber-700 dark:text-amber-300'
+                  : isIncoming
+                    ? 'border-primary/40 bg-primary/10 text-primary'
+                    : 'border-[var(--destructive)]/40 bg-[var(--destructive)]/10 text-[var(--destructive)]'
+              }`}
+            >
+              <Icon className="h-4 w-4" />
+            </div>
+            <div className="flex flex-col">
+              <span className="text-xs font-semibold text-foreground">{label}</span>
+              <span className="text-xs text-muted-foreground">{counterpartyLabel}</span>
+            </div>
+          </div>
+          <span
+            className={`text-sm font-semibold ${
+              isPending
+                ? 'text-amber-700 dark:text-amber-300'
+                : isIncoming
+                  ? 'text-primary'
+                  : 'text-[var(--destructive)]'
+            }`}
+          >
+            {isIncoming ? '+' : '-'}
+            {formatBalanceCompact(tx.amount)}
+          </span>
+        </div>
+
+        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-2 text-[11px] text-muted-foreground">
+          <div className="flex min-w-0 items-center gap-2">
+            <HashIcon className="h-3.5 w-3.5" />
+            {isDefault ? (
+              <a
+                href={buildExplorerObjectUrl('tx', tx.hash)}
+                className="truncate font-mono text-primary hover:underline"
+                target="_blank"
+                rel="noreferrer"
+                onClick={(event) => event.stopPropagation()}
+              >
+                {truncateString(tx.hash, {
+                  leading: 6,
+                  trailing: 6,
+                  minLength: 12,
+                  emptyLabel: '',
+                })}
+              </a>
+            ) : (
+              <span className="truncate font-mono">
+                {truncateString(tx.hash, {
+                  leading: 6,
+                  trailing: 6,
+                  minLength: 12,
+                  emptyLabel: '',
+                })}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-1 font-mono">
+            <span className="text-muted-foreground/70">{t('history.tick')}</span>
+            <span>{Number(tx.tickNumber).toLocaleString()}</span>
+          </div>
+          <div className="flex items-center gap-1 font-mono">
+            <span className="text-muted-foreground/70">{t('history.type')}</span>
+            <span>{tx.inputType.toString()}</span>
+          </div>
+        </div>
+      </motion.button>
+    )
   }
 
   useEffect(() => {
@@ -306,65 +402,7 @@ const History = () => {
                   <span className="text-[11px] font-semibold uppercase text-muted-foreground/70">
                     {t('history.pending')}
                   </span>
-                  {pendingTopItems.map((tx) => {
-                    const { isIncoming, label, counterpartyLabel, Icon } = getRowPresentation(tx)
-
-                    return (
-                      <motion.button
-                        type="button"
-                        key={tx.hash}
-                        className="w-full cursor-pointer space-y-3 rounded-xl border border-amber-500/50 bg-amber-500/10 px-3 py-3 text-left transition-colors"
-                        onClick={() => navigate(`/tx/${tx.hash}`)}
-                        variants={itemMotion}
-                      >
-                        <div className="flex items-center justify-between gap-3">
-                          <div className="flex items-center gap-3">
-                            <div className="flex h-9 w-9 items-center justify-center rounded-full border border-amber-500/40 bg-amber-500/15 text-amber-700 dark:text-amber-300">
-                              <Icon className="h-4 w-4" />
-                            </div>
-                            <div className="flex flex-col">
-                              <span className="text-xs font-semibold text-foreground">{label}</span>
-                              <span className="text-xs text-muted-foreground">
-                                {counterpartyLabel}
-                              </span>
-                            </div>
-                          </div>
-                          <span className="text-sm font-semibold text-amber-700 dark:text-amber-300">
-                            {isIncoming ? '+' : '-'}
-                            {formatBalanceCompact(tx.amount)}
-                          </span>
-                        </div>
-
-                        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-2 text-[11px] text-muted-foreground">
-                          <div className="flex min-w-0 items-center gap-2">
-                            <HashIcon className="h-3.5 w-3.5" />
-                            <a
-                              href={buildExplorerObjectUrl('tx', tx.hash)}
-                              className="truncate font-mono text-primary hover:underline"
-                              target="_blank"
-                              rel="noreferrer"
-                              onClick={(event) => event.stopPropagation()}
-                            >
-                              {truncateString(tx.hash, {
-                                leading: 6,
-                                trailing: 6,
-                                minLength: 12,
-                                emptyLabel: '',
-                              })}
-                            </a>
-                          </div>
-                          <div className="flex items-center gap-1 font-mono">
-                            <span className="text-muted-foreground/70">{t('history.tick')}</span>
-                            <span>{Number(tx.tickNumber).toLocaleString()}</span>
-                          </div>
-                          <div className="flex items-center gap-1 font-mono">
-                            <span className="text-muted-foreground/70">{t('history.type')}</span>
-                            <span>{tx.inputType.toString()}</span>
-                          </div>
-                        </div>
-                      </motion.button>
-                    )
-                  })}
+                  {pendingTopItems.map((tx) => renderHistoryRow(tx, 'pending'))}
                 </div>
               )}
 
@@ -375,7 +413,12 @@ const History = () => {
                   </span>
                   {failedTopItems.map((tx) => {
                     const { isIncoming, label, counterpartyLabel, Icon } = getRowPresentation(tx)
-                    const canResend = Number(tx.inputType) === 0 && Boolean(tx.destination)
+                    const canResend = canResendPendingTransaction({
+                      status: tx.status,
+                      destinationIdentity: tx.destination,
+                      inputType: Number(tx.inputType),
+                      tokenKey: tx.tokenKey,
+                    })
 
                     return (
                       <motion.div
@@ -407,7 +450,7 @@ const History = () => {
                                   className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-primary hover:underline"
                                   onClick={() =>
                                     navigate(
-                                      `/transfer?failedHash=${encodeURIComponent(tx.hash)}&recipient=${encodeURIComponent(tx.destination)}&amount=${encodeURIComponent(tx.amount.toString())}&inputType=${encodeURIComponent(tx.inputType.toString())}`,
+                                      `/transfer?failedHash=${encodeURIComponent(tx.hash)}&recipient=${encodeURIComponent(tx.destination)}&amount=${encodeURIComponent(tx.amount.toString())}&inputType=${encodeURIComponent(tx.inputType.toString())}&token=${encodeURIComponent(tx.tokenKey ?? 'qu')}`,
                                     )
                                   }
                                 >
@@ -461,73 +504,7 @@ const History = () => {
               <span className="text-[11px] font-semibold uppercase text-muted-foreground/70">
                 {group.label}
               </span>
-              {group.items.map((tx) => {
-                const { isIncoming, label, counterpartyLabel, Icon } = getRowPresentation(tx)
-
-                return (
-                  <motion.button
-                    type="button"
-                    key={tx.hash}
-                    className="w-full cursor-pointer space-y-3 rounded-xl border border-border/40 bg-background/40 px-3 py-3 text-left transition-colors hover:border-primary/30 hover:bg-background/60"
-                    onClick={() => navigate(`/tx/${tx.hash}`)}
-                    variants={itemMotion}
-                  >
-                    <div className="flex items-center justify-between gap-3">
-                      <div className="flex items-center gap-3">
-                        <div
-                          className={`flex h-9 w-9 items-center justify-center rounded-full border ${
-                            isIncoming
-                              ? 'border-primary/40 bg-primary/10 text-primary'
-                              : 'border-[var(--destructive)]/40 bg-[var(--destructive)]/10 text-[var(--destructive)]'
-                          }`}
-                        >
-                          <Icon className="h-4 w-4" />
-                        </div>
-                        <div className="flex flex-col">
-                          <span className="text-xs font-semibold text-foreground">{label}</span>
-                          <span className="text-xs text-muted-foreground">{counterpartyLabel}</span>
-                        </div>
-                      </div>
-                      <span
-                        className={`text-sm font-semibold ${
-                          isIncoming ? 'text-primary' : 'text-[var(--destructive)]'
-                        }`}
-                      >
-                        {isIncoming ? '+' : '-'}
-                        {formatBalanceCompact(tx.amount)}
-                      </span>
-                    </div>
-
-                    <div className="grid grid-cols-[1fr_auto_auto] items-center gap-2 text-[11px] text-muted-foreground">
-                      <div className="flex min-w-0 items-center gap-2">
-                        <HashIcon className="h-3.5 w-3.5" />
-                        <a
-                          href={buildExplorerObjectUrl('tx', tx.hash)}
-                          className="truncate font-mono text-primary hover:underline"
-                          target="_blank"
-                          rel="noreferrer"
-                          onClick={(event) => event.stopPropagation()}
-                        >
-                          {truncateString(tx.hash, {
-                            leading: 6,
-                            trailing: 6,
-                            minLength: 12,
-                            emptyLabel: '',
-                          })}
-                        </a>
-                      </div>
-                      <div className="flex items-center gap-1 font-mono">
-                        <span className="text-muted-foreground/70">{t('history.tick')}</span>
-                        <span>{Number(tx.tickNumber).toLocaleString()}</span>
-                      </div>
-                      <div className="flex items-center gap-1 font-mono">
-                        <span className="text-muted-foreground/70">{t('history.type')}</span>
-                        <span>{tx.inputType.toString()}</span>
-                      </div>
-                    </div>
-                  </motion.button>
-                )
-              })}
+              {group.items.map((tx) => renderHistoryRow(tx, 'default'))}
             </motion.div>
           ))}
 

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -38,6 +38,15 @@ const HistoryRowSkeleton = () => (
   </div>
 )
 
+type HistoryRowTransaction = {
+  hash: string
+  source: string
+  destination: string
+  amount: bigint
+  tickNumber: number | bigint
+  inputType: number | bigint
+}
+
 const History = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -175,6 +184,26 @@ const History = () => {
     hidden: { opacity: 0, y: 8 },
     show: { opacity: 1, y: 0, transition: { duration: 0.2 } },
   }
+  const getRowPresentation = (tx: HistoryRowTransaction) => {
+    const isIncoming = tx.destination === identity
+    const isSimpleTransfer = Number(tx.inputType) === 0
+    const label = isSimpleTransfer
+      ? isIncoming
+        ? t('history.received')
+        : t('history.sent')
+      : isIncoming
+        ? t('history.incoming')
+        : t('history.outgoing')
+    const counterparty = isIncoming ? tx.source : tx.destination
+    const counterpartyLabel = isSimpleTransfer
+      ? isIncoming
+        ? t('history.from', { address: truncateString(counterparty) })
+        : t('history.to', { address: truncateString(counterparty) })
+      : truncateString(counterparty)
+    const Icon = isIncoming ? ReceiveIcon : SendIcon
+
+    return { isIncoming, label, counterpartyLabel, Icon }
+  }
 
   useEffect(() => {
     resolvePendingTransactions(items, archiverProcessedTick)
@@ -278,22 +307,7 @@ const History = () => {
                     {t('history.pending')}
                   </span>
                   {pendingTopItems.map((tx) => {
-                    const isIncoming = tx.destination === identity
-                    const isSimpleTransfer = Number(tx.inputType) === 0
-                    const label = isSimpleTransfer
-                      ? isIncoming
-                        ? t('history.received')
-                        : t('history.sent')
-                      : isIncoming
-                        ? t('history.incoming')
-                        : t('history.outgoing')
-                    const counterparty = isIncoming ? tx.source : tx.destination
-                    const counterpartyLabel = isSimpleTransfer
-                      ? isIncoming
-                        ? t('history.from', { address: truncateString(counterparty) })
-                        : t('history.to', { address: truncateString(counterparty) })
-                      : truncateString(counterparty)
-                    const Icon = isIncoming ? ReceiveIcon : SendIcon
+                    const { isIncoming, label, counterpartyLabel, Icon } = getRowPresentation(tx)
 
                     return (
                       <motion.button
@@ -360,33 +374,13 @@ const History = () => {
                     {t('history.failed')}
                   </span>
                   {failedTopItems.map((tx) => {
-                    const isIncoming = tx.destination === identity
-                    const isSimpleTransfer = Number(tx.inputType) === 0
-                    const label = isSimpleTransfer
-                      ? isIncoming
-                        ? t('history.received')
-                        : t('history.sent')
-                      : isIncoming
-                        ? t('history.incoming')
-                        : t('history.outgoing')
-                    const counterparty = isIncoming ? tx.source : tx.destination
-                    const counterpartyLabel = isSimpleTransfer
-                      ? isIncoming
-                        ? t('history.from', { address: truncateString(counterparty) })
-                        : t('history.to', { address: truncateString(counterparty) })
-                      : truncateString(counterparty)
-                    const Icon = isIncoming ? ReceiveIcon : SendIcon
+                    const { isIncoming, label, counterpartyLabel, Icon } = getRowPresentation(tx)
+                    const canResend = Number(tx.inputType) === 0 && Boolean(tx.destination)
 
                     return (
-                      <motion.button
-                        type="button"
+                      <motion.div
                         key={tx.hash}
                         className="w-full cursor-pointer space-y-3 rounded-xl border border-red-500/50 bg-red-500/10 px-3 py-3 text-left transition-colors"
-                        onClick={() =>
-                          navigate(
-                            `/transfer?failedHash=${encodeURIComponent(tx.hash)}&recipient=${encodeURIComponent(tx.destination)}&amount=${encodeURIComponent(tx.amount.toString())}`,
-                          )
-                        }
                         variants={itemMotion}
                       >
                         <div className="flex items-center justify-between gap-3">
@@ -407,16 +401,23 @@ const History = () => {
                               {formatBalanceCompact(tx.amount)}
                             </span>
                             <div className="flex items-center gap-1">
-                              <span className="text-[11px] font-semibold uppercase tracking-wide text-primary">
-                                {t('history.resend')}
-                              </span>
+                              {canResend && (
+                                <button
+                                  type="button"
+                                  className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-primary hover:underline"
+                                  onClick={() =>
+                                    navigate(
+                                      `/transfer?failedHash=${encodeURIComponent(tx.hash)}&recipient=${encodeURIComponent(tx.destination)}&amount=${encodeURIComponent(tx.amount.toString())}&inputType=${encodeURIComponent(tx.inputType.toString())}`,
+                                    )
+                                  }
+                                >
+                                  {t('history.resend')}
+                                </button>
+                              )}
                               <button
                                 type="button"
                                 className="cursor-pointer text-muted-foreground transition-colors hover:text-foreground"
-                                onClick={(event) => {
-                                  event.stopPropagation()
-                                  removePendingTransaction(tx.hash)
-                                }}
+                                onClick={() => removePendingTransaction(tx.hash)}
                                 aria-label={t('history.deleteFailed')}
                                 title={t('history.deleteFailed')}
                               >
@@ -447,7 +448,7 @@ const History = () => {
                             <span>{tx.inputType.toString()}</span>
                           </div>
                         </div>
-                      </motion.button>
+                      </motion.div>
                     )
                   })}
                 </div>
@@ -461,22 +462,7 @@ const History = () => {
                 {group.label}
               </span>
               {group.items.map((tx) => {
-                const isIncoming = tx.destination === identity
-                const isSimpleTransfer = Number(tx.inputType) === 0
-                const label = isSimpleTransfer
-                  ? isIncoming
-                    ? t('history.received')
-                    : t('history.sent')
-                  : isIncoming
-                    ? t('history.incoming')
-                    : t('history.outgoing')
-                const counterparty = isIncoming ? tx.source : tx.destination
-                const counterpartyLabel = isSimpleTransfer
-                  ? isIncoming
-                    ? t('history.from', { address: truncateString(counterparty) })
-                    : t('history.to', { address: truncateString(counterparty) })
-                  : truncateString(counterparty)
-                const Icon = isIncoming ? ReceiveIcon : SendIcon
+                const { isIncoming, label, counterpartyLabel, Icon } = getRowPresentation(tx)
 
                 return (
                   <motion.button

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -1,5 +1,5 @@
 import { useTransactions } from '@qubic-labs/react'
-import { HashIcon, RefreshCwIcon } from 'lucide-react'
+import { HashIcon, RefreshCwIcon, XIcon } from 'lucide-react'
 import { ReceiveIcon } from '@/components/icons/receive-icon'
 import { SendIcon } from '@/components/icons/send-icon'
 import { Button } from '@/components/ui/button'
@@ -11,6 +11,7 @@ import { useNavigate } from 'react-router-dom'
 import {
   getPendingTransactionsForIdentity,
   PENDING_SETTLED_EVENT,
+  removePendingTransaction,
   resolvePendingTransactions,
   usePendingTransactionsVersion,
 } from '@/lib/pending-transactions'
@@ -383,7 +384,7 @@ const History = () => {
                         className="w-full cursor-pointer space-y-3 rounded-xl border border-red-500/50 bg-red-500/10 px-3 py-3 text-left transition-colors"
                         onClick={() =>
                           navigate(
-                            `/transfer?recipient=${encodeURIComponent(tx.destination)}&amount=${encodeURIComponent(tx.amount.toString())}`,
+                            `/transfer?failedHash=${encodeURIComponent(tx.hash)}&recipient=${encodeURIComponent(tx.destination)}&amount=${encodeURIComponent(tx.amount.toString())}`,
                           )
                         }
                         variants={itemMotion}
@@ -405,9 +406,23 @@ const History = () => {
                               {isIncoming ? '+' : '-'}
                               {formatBalanceCompact(tx.amount)}
                             </span>
-                            <span className="text-[11px] font-semibold uppercase tracking-wide text-primary">
-                              {t('history.resend')}
-                            </span>
+                            <div className="flex items-center gap-1">
+                              <span className="text-[11px] font-semibold uppercase tracking-wide text-primary">
+                                {t('history.resend')}
+                              </span>
+                              <button
+                                type="button"
+                                className="cursor-pointer text-muted-foreground transition-colors hover:text-foreground"
+                                onClick={(event) => {
+                                  event.stopPropagation()
+                                  removePendingTransaction(tx.hash)
+                                }}
+                                aria-label={t('history.deleteFailed')}
+                                title={t('history.deleteFailed')}
+                              >
+                                <XIcon className="h-3.5 w-3.5" />
+                              </button>
+                            </div>
                           </div>
                         </div>
 

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -9,6 +9,7 @@ import { useEffect, useMemo, useRef, useState } from 'react'
 import { AnimatePresence, motion } from 'framer-motion'
 import { useNavigate } from 'react-router-dom'
 import {
+  getArchiverProcessedTick,
   canResendPendingTransaction,
   getPendingTransactionsForIdentity,
   PENDING_SETTLED_EVENT,
@@ -89,13 +90,7 @@ const History = () => {
     return getPendingTransactionsForIdentity(identity)
   }, [identity, pendingVersion])
   const archiverProcessedTick = useMemo(() => {
-    const pages = transactions.data?.pages ?? []
-    if (pages.length === 0) return undefined
-    return pages.reduce<bigint | undefined>((max, page) => {
-      if (typeof page.validForTick !== 'bigint') return max
-      if (max === undefined || page.validForTick > max) return page.validForTick
-      return max
-    }, undefined)
+    return getArchiverProcessedTick(transactions.data?.pages)
   }, [transactions.data])
   const pendingHashes = useMemo(
     () => new Set(pending.map((tx) => tx.hash.toLowerCase())),

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -11,12 +11,10 @@ import { useNavigate } from 'react-router-dom'
 import {
   getPendingTransactionsForIdentity,
   PENDING_SETTLED_EVENT,
-  isTransactionPending,
   resolvePendingTransactions,
   usePendingTransactionsVersion,
 } from '@/lib/pending-transactions'
 import { getCurrentIdentity } from '@/lib/accounts'
-import { useLatestStats } from '@/lib/network-stats'
 import HistoryEmptyState from '@/components/pages/history/history-empty-state'
 
 const HistoryRowSkeleton = () => (
@@ -53,7 +51,6 @@ const History = () => {
     },
     { refetchInterval: 15_000 },
   )
-  const latestStats = useLatestStats('history')
 
   useEffect(() => {
     const refreshIdentity = () => {
@@ -69,32 +66,56 @@ const History = () => {
     }
   }, [])
 
-  const currentTick = latestStats.data?.data?.currentTick
   const items = useMemo(
     () => transactions.data?.pages.flatMap((page) => page.transactions) ?? [],
     [transactions.data],
   )
   const pending = useMemo(() => {
     void pendingVersion
-    return getPendingTransactionsForIdentity(identity, currentTick)
-  }, [identity, currentTick, pendingVersion])
-  const sorted = useMemo(() => {
-    const pendingHashes = new Set(pending.map((tx) => tx.hash.toLowerCase()))
-    const pendingItems = pending.map((tx) => ({
-      hash: tx.hash,
-      source: tx.sourceIdentity,
-      destination: tx.destinationIdentity ?? '',
-      amount: tx.amount ?? 0n,
-      tickNumber: tx.targetTick,
-      inputType: tx.inputType ?? 0,
-      timestamp: BigInt(tx.createdAt),
-    }))
-
-    return [
-      ...pendingItems,
-      ...items.filter((tx) => !pendingHashes.has(tx.hash.toLowerCase())),
-    ].sort((a, b) => Number(b.tickNumber) - Number(a.tickNumber))
-  }, [items, pending])
+    return getPendingTransactionsForIdentity(identity)
+  }, [identity, pendingVersion])
+  const archiverProcessedTick = useMemo(() => {
+    const pages = transactions.data?.pages ?? []
+    if (pages.length === 0) return undefined
+    return pages.reduce<bigint | undefined>((max, page) => {
+      if (typeof page.validForTick !== 'bigint') return max
+      if (max === undefined || page.validForTick > max) return page.validForTick
+      return max
+    }, undefined)
+  }, [transactions.data])
+  const pendingHashes = useMemo(
+    () => new Set(pending.map((tx) => tx.hash.toLowerCase())),
+    [pending],
+  )
+  const pendingItems = useMemo(
+    () =>
+      pending.map((tx) => ({
+        hash: tx.hash,
+        source: tx.sourceIdentity,
+        destination: tx.destinationIdentity ?? '',
+        amount: tx.amount ?? 0n,
+        tickNumber: tx.targetTick,
+        inputType: tx.inputType ?? 0,
+        timestamp: BigInt(tx.createdAt),
+        status: tx.status,
+      })),
+    [pending],
+  )
+  const apiItems = useMemo(
+    () =>
+      items
+        .filter((tx) => !pendingHashes.has(tx.hash.toLowerCase()))
+        .sort((a, b) => Number(b.tickNumber) - Number(a.tickNumber)),
+    [items, pendingHashes],
+  )
+  const pendingTopItems = useMemo(
+    () => pendingItems.filter((tx) => tx.status === 'pending'),
+    [pendingItems],
+  )
+  const failedTopItems = useMemo(
+    () => pendingItems.filter((tx) => tx.status === 'failed'),
+    [pendingItems],
+  )
 
   const grouped = useMemo(() => {
     const now = new Date()
@@ -106,20 +127,14 @@ const History = () => {
     const groups: Array<{
       key: string
       label: string
-      items: typeof sorted
+      items: typeof apiItems
     }> = []
-    const groupMap = new Map<string, typeof sorted>()
+    const groupMap = new Map<string, typeof apiItems>()
 
-    for (const tx of sorted) {
-      const isPending = isTransactionPending(tx.hash, currentTick)
-      let key: string
-      if (isPending) {
-        key = '__pending__'
-      } else {
-        const ts = Number(tx.timestamp)
-        const date = new Date(ts > 1e12 ? ts : ts * 1000)
-        key = date.toDateString()
-      }
+    for (const tx of apiItems) {
+      const ts = Number(tx.timestamp)
+      const date = new Date(ts > 1e12 ? ts : ts * 1000)
+      const key = date.toDateString()
       const group = groupMap.get(key)
       if (group) {
         group.push(tx)
@@ -130,9 +145,7 @@ const History = () => {
 
     for (const [key, groupItems] of groupMap) {
       let label: string
-      if (key === '__pending__') {
-        label = t('history.pending')
-      } else if (key === todayKey) {
+      if (key === todayKey) {
         label = t('history.today')
       } else if (key === yesterdayKey) {
         label = t('history.yesterday')
@@ -148,7 +161,7 @@ const History = () => {
     }
 
     return groups
-  }, [sorted, currentTick, t])
+  }, [apiItems, t])
   const listMotion = {
     hidden: { opacity: 0, y: 10 },
     show: {
@@ -163,8 +176,8 @@ const History = () => {
   }
 
   useEffect(() => {
-    resolvePendingTransactions(items, currentTick)
-  }, [items, currentTick])
+    resolvePendingTransactions(items, archiverProcessedTick)
+  }, [items, archiverProcessedTick])
 
   useEffect(() => {
     const target = loadMoreRef.current
@@ -247,9 +260,183 @@ const History = () => {
             </motion.div>
           )}
 
-          {!transactions.isLoading && sorted.length === 0 && (
-            <motion.div variants={itemMotion}>
-              <HistoryEmptyState />
+          {!transactions.isLoading &&
+            pendingTopItems.length === 0 &&
+            failedTopItems.length === 0 &&
+            apiItems.length === 0 && (
+              <motion.div variants={itemMotion}>
+                <HistoryEmptyState />
+              </motion.div>
+            )}
+
+          {(pendingTopItems.length > 0 || failedTopItems.length > 0) && (
+            <motion.div className="space-y-2" variants={itemMotion}>
+              {pendingTopItems.length > 0 && (
+                <div className="space-y-2">
+                  <span className="text-[11px] font-semibold uppercase text-muted-foreground/70">
+                    {t('history.pending')}
+                  </span>
+                  {pendingTopItems.map((tx) => {
+                    const isIncoming = tx.destination === identity
+                    const isSimpleTransfer = Number(tx.inputType) === 0
+                    const label = isSimpleTransfer
+                      ? isIncoming
+                        ? t('history.received')
+                        : t('history.sent')
+                      : isIncoming
+                        ? t('history.incoming')
+                        : t('history.outgoing')
+                    const counterparty = isIncoming ? tx.source : tx.destination
+                    const counterpartyLabel = isSimpleTransfer
+                      ? isIncoming
+                        ? t('history.from', { address: truncateString(counterparty) })
+                        : t('history.to', { address: truncateString(counterparty) })
+                      : truncateString(counterparty)
+                    const Icon = isIncoming ? ReceiveIcon : SendIcon
+
+                    return (
+                      <motion.button
+                        type="button"
+                        key={tx.hash}
+                        className="w-full cursor-pointer space-y-3 rounded-xl border border-amber-500/50 bg-amber-500/10 px-3 py-3 text-left transition-colors"
+                        onClick={() => navigate(`/tx/${tx.hash}`)}
+                        variants={itemMotion}
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="flex items-center gap-3">
+                            <div className="flex h-9 w-9 items-center justify-center rounded-full border border-amber-500/40 bg-amber-500/15 text-amber-700 dark:text-amber-300">
+                              <Icon className="h-4 w-4" />
+                            </div>
+                            <div className="flex flex-col">
+                              <span className="text-xs font-semibold text-foreground">{label}</span>
+                              <span className="text-xs text-muted-foreground">
+                                {counterpartyLabel}
+                              </span>
+                            </div>
+                          </div>
+                          <span className="text-sm font-semibold text-amber-700 dark:text-amber-300">
+                            {isIncoming ? '+' : '-'}
+                            {formatBalanceCompact(tx.amount)}
+                          </span>
+                        </div>
+
+                        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-2 text-[11px] text-muted-foreground">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <HashIcon className="h-3.5 w-3.5" />
+                            <a
+                              href={buildExplorerObjectUrl('tx', tx.hash)}
+                              className="truncate font-mono text-primary hover:underline"
+                              target="_blank"
+                              rel="noreferrer"
+                              onClick={(event) => event.stopPropagation()}
+                            >
+                              {truncateString(tx.hash, {
+                                leading: 6,
+                                trailing: 6,
+                                minLength: 12,
+                                emptyLabel: '',
+                              })}
+                            </a>
+                          </div>
+                          <div className="flex items-center gap-1 font-mono">
+                            <span className="text-muted-foreground/70">{t('history.tick')}</span>
+                            <span>{Number(tx.tickNumber).toLocaleString()}</span>
+                          </div>
+                          <div className="flex items-center gap-1 font-mono">
+                            <span className="text-muted-foreground/70">{t('history.type')}</span>
+                            <span>{tx.inputType.toString()}</span>
+                          </div>
+                        </div>
+                      </motion.button>
+                    )
+                  })}
+                </div>
+              )}
+
+              {failedTopItems.length > 0 && (
+                <div className="space-y-2">
+                  <span className="text-[11px] font-semibold uppercase text-muted-foreground/70">
+                    {t('history.failed')}
+                  </span>
+                  {failedTopItems.map((tx) => {
+                    const isIncoming = tx.destination === identity
+                    const isSimpleTransfer = Number(tx.inputType) === 0
+                    const label = isSimpleTransfer
+                      ? isIncoming
+                        ? t('history.received')
+                        : t('history.sent')
+                      : isIncoming
+                        ? t('history.incoming')
+                        : t('history.outgoing')
+                    const counterparty = isIncoming ? tx.source : tx.destination
+                    const counterpartyLabel = isSimpleTransfer
+                      ? isIncoming
+                        ? t('history.from', { address: truncateString(counterparty) })
+                        : t('history.to', { address: truncateString(counterparty) })
+                      : truncateString(counterparty)
+                    const Icon = isIncoming ? ReceiveIcon : SendIcon
+
+                    return (
+                      <motion.button
+                        type="button"
+                        key={tx.hash}
+                        className="w-full cursor-pointer space-y-3 rounded-xl border border-red-500/50 bg-red-500/10 px-3 py-3 text-left transition-colors"
+                        onClick={() =>
+                          navigate(
+                            `/transfer?recipient=${encodeURIComponent(tx.destination)}&amount=${encodeURIComponent(tx.amount.toString())}`,
+                          )
+                        }
+                        variants={itemMotion}
+                      >
+                        <div className="flex items-center justify-between gap-3">
+                          <div className="flex items-center gap-3">
+                            <div className="flex h-9 w-9 items-center justify-center rounded-full border border-red-500/40 bg-red-500/15 text-red-700 dark:text-red-300">
+                              <Icon className="h-4 w-4" />
+                            </div>
+                            <div className="flex flex-col">
+                              <span className="text-xs font-semibold text-foreground">{label}</span>
+                              <span className="text-xs text-muted-foreground">
+                                {counterpartyLabel}
+                              </span>
+                            </div>
+                          </div>
+                          <div className="flex items-center gap-2">
+                            <span className="text-sm font-semibold text-red-700 dark:text-red-300">
+                              {isIncoming ? '+' : '-'}
+                              {formatBalanceCompact(tx.amount)}
+                            </span>
+                            <span className="text-[11px] font-semibold uppercase tracking-wide text-primary">
+                              {t('history.resend')}
+                            </span>
+                          </div>
+                        </div>
+
+                        <div className="grid grid-cols-[1fr_auto_auto] items-center gap-2 text-[11px] text-muted-foreground">
+                          <div className="flex min-w-0 items-center gap-2">
+                            <HashIcon className="h-3.5 w-3.5" />
+                            <span className="truncate font-mono">
+                              {truncateString(tx.hash, {
+                                leading: 6,
+                                trailing: 6,
+                                minLength: 12,
+                                emptyLabel: '',
+                              })}
+                            </span>
+                          </div>
+                          <div className="flex items-center gap-1 font-mono">
+                            <span className="text-muted-foreground/70">{t('history.tick')}</span>
+                            <span>{Number(tx.tickNumber).toLocaleString()}</span>
+                          </div>
+                          <div className="flex items-center gap-1 font-mono">
+                            <span className="text-muted-foreground/70">{t('history.type')}</span>
+                            <span>{tx.inputType.toString()}</span>
+                          </div>
+                        </div>
+                      </motion.button>
+                    )
+                  })}
+                </div>
+              )}
             </motion.div>
           )}
 
@@ -275,17 +462,12 @@ const History = () => {
                     : t('history.to', { address: truncateString(counterparty) })
                   : truncateString(counterparty)
                 const Icon = isIncoming ? ReceiveIcon : SendIcon
-                const isPending = isTransactionPending(tx.hash, currentTick)
 
                 return (
                   <motion.button
                     type="button"
                     key={tx.hash}
-                    className={`w-full cursor-pointer space-y-3 rounded-xl border px-3 py-3 text-left transition-colors ${
-                      isPending
-                        ? 'animate-pulse border-amber-500/50 bg-amber-500/10'
-                        : 'border-border/40 bg-background/40 hover:border-primary/30 hover:bg-background/60'
-                    }`}
+                    className="w-full cursor-pointer space-y-3 rounded-xl border border-border/40 bg-background/40 px-3 py-3 text-left transition-colors hover:border-primary/30 hover:bg-background/60"
                     onClick={() => navigate(`/tx/${tx.hash}`)}
                     variants={itemMotion}
                   >
@@ -293,11 +475,9 @@ const History = () => {
                       <div className="flex items-center gap-3">
                         <div
                           className={`flex h-9 w-9 items-center justify-center rounded-full border ${
-                            isPending
-                              ? 'border-amber-500/40 bg-amber-500/15 text-amber-700 dark:text-amber-300'
-                              : isIncoming
-                                ? 'border-primary/40 bg-primary/10 text-primary'
-                                : 'border-[var(--destructive)]/40 bg-[var(--destructive)]/10 text-[var(--destructive)]'
+                            isIncoming
+                              ? 'border-primary/40 bg-primary/10 text-primary'
+                              : 'border-[var(--destructive)]/40 bg-[var(--destructive)]/10 text-[var(--destructive)]'
                           }`}
                         >
                           <Icon className="h-4 w-4" />
@@ -309,11 +489,7 @@ const History = () => {
                       </div>
                       <span
                         className={`text-sm font-semibold ${
-                          isPending
-                            ? 'text-amber-700 dark:text-amber-300'
-                            : isIncoming
-                              ? 'text-primary'
-                              : 'text-[var(--destructive)]'
+                          isIncoming ? 'text-primary' : 'text-[var(--destructive)]'
                         }`}
                       >
                         {isIncoming ? '+' : '-'}

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -445,7 +445,7 @@ const History = () => {
                                   className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-primary hover:underline"
                                   onClick={() =>
                                     navigate(
-                                      `/transfer?failedHash=${encodeURIComponent(tx.hash)}&recipient=${encodeURIComponent(tx.destination)}&amount=${encodeURIComponent(tx.amount.toString())}&inputType=${encodeURIComponent(tx.inputType.toString())}&token=${encodeURIComponent(tx.tokenKey ?? 'qu')}`,
+                                      `/transfer?failedHash=${encodeURIComponent(tx.hash)}&recipient=${encodeURIComponent(tx.destination)}&amount=${encodeURIComponent(tx.amount.toString())}&token=${encodeURIComponent(tx.tokenKey ?? 'qu')}`,
                                     )
                                   }
                                 >

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -418,7 +418,7 @@ const History = () => {
                     return (
                       <motion.div
                         key={tx.hash}
-                        className="w-full cursor-pointer space-y-3 rounded-xl border border-red-500/50 bg-red-500/10 px-3 py-3 text-left transition-colors"
+                        className="w-full space-y-3 rounded-xl border border-red-500/50 bg-red-500/10 px-3 py-3 text-left transition-colors"
                         variants={itemMotion}
                       >
                         <div className="flex items-center justify-between gap-3">

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -320,9 +320,9 @@ const Home = () => {
               pendingTransactions={pendingForIdentity}
               onViewMore={() => navigate('/history')}
               onOpenTx={(hash) => navigate(`/tx/${hash}`)}
-              onResend={(failedHash, recipient, amount, inputType) =>
+              onResend={(failedHash, recipient, amount, inputType, tokenKey) =>
                 navigate(
-                  `/transfer?failedHash=${encodeURIComponent(failedHash)}&recipient=${encodeURIComponent(recipient)}&amount=${encodeURIComponent(amount.toString())}&inputType=${encodeURIComponent(inputType.toString())}`,
+                  `/transfer?failedHash=${encodeURIComponent(failedHash)}&recipient=${encodeURIComponent(recipient)}&amount=${encodeURIComponent(amount.toString())}&inputType=${encodeURIComponent(inputType.toString())}&token=${encodeURIComponent(tokenKey ?? 'qu')}`,
                 )
               }
             />

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -320,9 +320,9 @@ const Home = () => {
               pendingTransactions={pendingForIdentity}
               onViewMore={() => navigate('/history')}
               onOpenTx={(hash) => navigate(`/tx/${hash}`)}
-              onResend={(failedHash, recipient, amount) =>
+              onResend={(failedHash, recipient, amount, inputType) =>
                 navigate(
-                  `/transfer?failedHash=${encodeURIComponent(failedHash)}&recipient=${encodeURIComponent(recipient)}&amount=${encodeURIComponent(amount.toString())}`,
+                  `/transfer?failedHash=${encodeURIComponent(failedHash)}&recipient=${encodeURIComponent(recipient)}&amount=${encodeURIComponent(amount.toString())}&inputType=${encodeURIComponent(inputType.toString())}`,
                 )
               }
             />

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -17,6 +17,7 @@ import { useClipboardCopy } from '@/hooks/use-clipboard-copy'
 import BalanceCard from '@/components/pages/home/balance-card'
 import TransactionsPreview from '@/components/pages/home/transactions-preview'
 import {
+  getArchiverProcessedTick,
   getPendingOutgoingDebit,
   PENDING_SETTLED_EVENT,
   getPendingTransactionsForIdentity,
@@ -94,13 +95,7 @@ const Home = () => {
     [transactions.data],
   )
   const archiverProcessedTick = useMemo(() => {
-    const pages = transactions.data?.pages ?? []
-    if (pages.length === 0) return undefined
-    return pages.reduce<bigint | undefined>((max, page) => {
-      if (typeof page.validForTick !== 'bigint') return max
-      if (max === undefined || page.validForTick > max) return page.validForTick
-      return max
-    }, undefined)
+    return getArchiverProcessedTick(transactions.data?.pages)
   }, [transactions.data])
   const isSyncingRaw =
     balance.isFetching ||

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -315,9 +315,9 @@ const Home = () => {
               pendingTransactions={pendingForIdentity}
               onViewMore={() => navigate('/history')}
               onOpenTx={(hash) => navigate(`/tx/${hash}`)}
-              onResend={(failedHash, recipient, amount, inputType, tokenKey) =>
+              onResend={(failedHash, recipient, amount, tokenKey) =>
                 navigate(
-                  `/transfer?failedHash=${encodeURIComponent(failedHash)}&recipient=${encodeURIComponent(recipient)}&amount=${encodeURIComponent(amount.toString())}&inputType=${encodeURIComponent(inputType.toString())}&token=${encodeURIComponent(tokenKey ?? 'qu')}`,
+                  `/transfer?failedHash=${encodeURIComponent(failedHash)}&recipient=${encodeURIComponent(recipient)}&amount=${encodeURIComponent(amount.toString())}&token=${encodeURIComponent(tokenKey ?? 'qu')}`,
                 )
               }
             />

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -320,9 +320,9 @@ const Home = () => {
               pendingTransactions={pendingForIdentity}
               onViewMore={() => navigate('/history')}
               onOpenTx={(hash) => navigate(`/tx/${hash}`)}
-              onResend={(recipient, amount) =>
+              onResend={(failedHash, recipient, amount) =>
                 navigate(
-                  `/transfer?recipient=${encodeURIComponent(recipient)}&amount=${encodeURIComponent(amount.toString())}`,
+                  `/transfer?failedHash=${encodeURIComponent(failedHash)}&recipient=${encodeURIComponent(recipient)}&amount=${encodeURIComponent(amount.toString())}`,
                 )
               }
             />

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -78,9 +78,9 @@ const Home = () => {
   const currentTickFromRpc = latestStats.data?.data?.currentTick
   const hasVirtualTick = virtualTick !== null
   const tickValue = virtualTick ?? currentTickFromRpc ?? '--'
-  const currentTick = typeof tickValue === 'number' ? tickValue : undefined
-  const pendingOutgoingDebit = getPendingOutgoingDebit(identity, currentTick)
-  const hasPendingOutgoing = getPendingTransactionsForIdentity(identity, currentTick).length > 0
+  const pendingForIdentity = getPendingTransactionsForIdentity(identity)
+  const pendingOutgoingDebit = getPendingOutgoingDebit(identity)
+  const hasPendingOutgoing = pendingForIdentity.some((tx) => tx.status === 'pending')
   const epochValue = latestStats.data?.data?.epoch ?? '--'
   const pricePerBValue = latestStats.data?.data?.price
     ? `$${(latestStats.data.data.price * 1_000_000_000).toFixed(2)}`
@@ -93,6 +93,15 @@ const Home = () => {
     () => transactions.data?.pages.flatMap((page) => page.transactions) ?? [],
     [transactions.data],
   )
+  const archiverProcessedTick = useMemo(() => {
+    const pages = transactions.data?.pages ?? []
+    if (pages.length === 0) return undefined
+    return pages.reduce<bigint | undefined>((max, page) => {
+      if (typeof page.validForTick !== 'bigint') return max
+      if (max === undefined || page.validForTick > max) return page.validForTick
+      return max
+    }, undefined)
+  }, [transactions.data])
   const isSyncingRaw =
     balance.isFetching ||
     transactions.isFetching ||
@@ -131,8 +140,8 @@ const Home = () => {
   }, [])
 
   useEffect(() => {
-    resolvePendingTransactions(transactionItems, currentTick)
-  }, [transactionItems, currentTick])
+    resolvePendingTransactions(transactionItems, archiverProcessedTick)
+  }, [transactionItems, archiverProcessedTick])
 
   useEffect(() => {
     const clearTimers = () => {
@@ -308,9 +317,14 @@ const Home = () => {
             <TransactionsPreview
               identity={identity}
               transactions={transactions}
-              currentTick={currentTick}
+              pendingTransactions={pendingForIdentity}
               onViewMore={() => navigate('/history')}
               onOpenTx={(hash) => navigate(`/tx/${hash}`)}
+              onResend={(recipient, amount) =>
+                navigate(
+                  `/transfer?recipient=${encodeURIComponent(recipient)}&amount=${encodeURIComponent(amount.toString())}`,
+                )
+              }
             />
           </motion.div>
 

--- a/src/pages/transaction-details.tsx
+++ b/src/pages/transaction-details.tsx
@@ -1,4 +1,4 @@
-import { useSdk } from '@qubic-labs/react'
+import { useLastProcessedTick, useSdk } from '@qubic-labs/react'
 import { useQuery } from '@tanstack/react-query'
 import { ArrowLeftIcon } from 'lucide-react'
 import { useEffect } from 'react'
@@ -9,7 +9,6 @@ import {
   resolvePendingTransactions,
   usePendingTransactionsVersion,
 } from '@/lib/pending-transactions'
-import { useLatestStats } from '@/lib/network-stats'
 import { useClipboardCopy } from '@/hooks/use-clipboard-copy'
 import TxDetailsHeader from '@/components/pages/transaction-details/tx-details-header'
 import TxDetailsRow, { formatValue } from '@/components/pages/transaction-details/tx-details-row'
@@ -50,10 +49,10 @@ const TransactionDetails = () => {
     successTitle: t('txDetails.copied'),
     errorTitle: t('txDetails.copyFailed'),
   })
-  const latestStats = useLatestStats('tx-details')
-  const currentTick = latestStats.data?.data?.currentTick
-  const pending = getPendingTransaction(hash, currentTick)
-  const isPending = Boolean(pending)
+  const lastProcessedTickQuery = useLastProcessedTick({ refetchInterval: 15_000 })
+  const archiverProcessedTick = lastProcessedTickQuery.data?.tickNumber
+  const pending = getPendingTransaction(hash)
+  const isPending = pending?.status === 'pending'
 
   const txQuery = useQuery({
     queryKey: ['qubic', 'tx-by-hash', hash],
@@ -62,9 +61,13 @@ const TransactionDetails = () => {
     refetchInterval: isPending ? 5_000 : false,
   })
   useEffect(() => {
-    if (!hash || !txQuery.data) return
-    resolvePendingTransactions([{ hash }], currentTick)
-  }, [hash, currentTick, txQuery.data])
+    if (!hash) return
+    if (txQuery.data) {
+      resolvePendingTransactions([{ hash }], archiverProcessedTick)
+      return
+    }
+    resolvePendingTransactions([], archiverProcessedTick)
+  }, [hash, archiverProcessedTick, txQuery.data])
 
   const details = txQuery.data as Record<string, unknown> | undefined
 

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -18,6 +18,7 @@ import {
   getPendingOutgoingDebit,
   getPendingTransactionsForIdentity,
   PENDING_SETTLED_EVENT,
+  removePendingTransaction,
   usePendingTransactionsVersion,
 } from '@/lib/pending-transactions'
 import { useLatestStats } from '@/lib/network-stats'
@@ -42,7 +43,13 @@ const formatUsd = (value: number) =>
 const Transfer = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const [searchParams, setSearchParams] = useSearchParams()
+  const [searchParams] = useSearchParams()
+  const initialPrefillRecipient = (searchParams.get('recipient') ?? '').trim().toUpperCase()
+  const initialPrefillAmount = (() => {
+    const value = (searchParams.get('amount') ?? '').trim()
+    return /^\d+$/.test(value) ? value : ''
+  })()
+  const resendFromFailedHash = (searchParams.get('failedHash') ?? '').trim()
   usePendingTransactionsVersion()
   const [currentIdentity, setCurrentIdentity] = useState(getCurrentIdentity())
   const [isWatchOnly, setIsWatchOnly] = useState(() => isWatchOnlyIdentity(getCurrentIdentity()))
@@ -56,8 +63,8 @@ const Transfer = () => {
 
   const [step, setStep] = useState<Step>('form')
   const [selectedToken, setSelectedToken] = useState('qu')
-  const [recipient, setRecipient] = useState('')
-  const [amount, setAmount] = useState('')
+  const [recipient, setRecipient] = useState(initialPrefillRecipient)
+  const [amount, setAmount] = useState(initialPrefillAmount)
   const [errors, setErrors] = useState<FormErrors>({})
   const [drawerOpen, setDrawerOpen] = useState(false)
   const [sending, setSending] = useState(false)
@@ -120,27 +127,6 @@ const Transfer = () => {
       window.removeEventListener('wallet-account-updated', refreshAccount)
     }
   }, [])
-
-  useEffect(() => {
-    const prefillRecipient = searchParams.get('recipient')?.trim()
-    const prefillAmount = searchParams.get('amount')?.trim()
-    let didPrefill = false
-
-    if (prefillRecipient) {
-      setRecipient(prefillRecipient.toUpperCase())
-      didPrefill = true
-    }
-    if (prefillAmount && /^\d+$/.test(prefillAmount)) {
-      setAmount(prefillAmount)
-      didPrefill = true
-    }
-
-    if (didPrefill) {
-      setErrors({})
-      setErrorMessage('')
-      setSearchParams({}, { replace: true })
-    }
-  }, [searchParams, setSearchParams])
 
   useEffect(() => {
     if (selectedToken === 'qu') return
@@ -329,6 +315,9 @@ const Transfer = () => {
         inputType: selectedAsset ? QX_TRANSFER_ASSET_INPUT_TYPE : 0,
         targetTick: Number(result.targetTick),
       })
+      if (resendFromFailedHash) {
+        removePendingTransaction(resendFromFailedHash)
+      }
 
       setTxResult({
         txId: result.txId,

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -18,7 +18,6 @@ import {
   getPendingOutgoingDebit,
   getPendingTransactionsForIdentity,
   PENDING_SETTLED_EVENT,
-  removePendingTransaction,
   usePendingTransactionsVersion,
 } from '@/lib/pending-transactions'
 import { useLatestStats } from '@/lib/network-stats'
@@ -50,7 +49,6 @@ const Transfer = () => {
     return /^\d+$/.test(value) ? value : ''
   })()
   const initialPrefillToken = (searchParams.get('token') ?? 'qu').trim()
-  const resendFromFailedHash = (searchParams.get('failedHash') ?? '').trim()
   usePendingTransactionsVersion()
   const [currentIdentity, setCurrentIdentity] = useState(getCurrentIdentity())
   const [isWatchOnly, setIsWatchOnly] = useState(() => isWatchOnlyIdentity(getCurrentIdentity()))
@@ -317,9 +315,6 @@ const Transfer = () => {
         tokenKey: selectedAsset ? `${selectedAsset.issuerIdentity}-${selectedAsset.name}` : 'qu',
         targetTick: Number(result.targetTick),
       })
-      if (resendFromFailedHash) {
-        removePendingTransaction(resendFromFailedHash)
-      }
 
       setTxResult({
         txId: result.txId,

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -49,10 +49,7 @@ const Transfer = () => {
     const value = (searchParams.get('amount') ?? '').trim()
     return /^\d+$/.test(value) ? value : ''
   })()
-  const initialPrefillInputType = (() => {
-    const value = Number.parseInt((searchParams.get('inputType') ?? '').trim(), 10)
-    return Number.isFinite(value) ? value : 0
-  })()
+  const initialPrefillToken = (searchParams.get('token') ?? 'qu').trim()
   const resendFromFailedHash = (searchParams.get('failedHash') ?? '').trim()
   usePendingTransactionsVersion()
   const [currentIdentity, setCurrentIdentity] = useState(getCurrentIdentity())
@@ -66,7 +63,7 @@ const Transfer = () => {
   const latestStats = useLatestStats('transfer', { staleTime: 5_000 })
 
   const [step, setStep] = useState<Step>('form')
-  const [selectedToken, setSelectedToken] = useState('qu')
+  const [selectedToken, setSelectedToken] = useState(initialPrefillToken || 'qu')
   const [recipient, setRecipient] = useState(initialPrefillRecipient)
   const [amount, setAmount] = useState(initialPrefillAmount)
   const [errors, setErrors] = useState<FormErrors>({})
@@ -78,12 +75,6 @@ const Transfer = () => {
   const [isManualTargetTickEnabled, setIsManualTargetTickEnabled] = useState(false)
   const [manualTargetTick, setManualTargetTick] = useState('')
   const seedRef = useRef<string | null>(null)
-
-  useEffect(() => {
-    if (!resendFromFailedHash) return
-    if (initialPrefillInputType === 0) return
-    setErrorMessage(t('transfer.errors.resendUnsupported'))
-  }, [initialPrefillInputType, resendFromFailedHash, t])
 
   const parsedAssets = aggregateAssets(ownedAssets.data ?? {})
   const filteredVaultRecipients = useMemo(
@@ -320,9 +311,10 @@ const Transfer = () => {
         hash: result.txId,
         sourceIdentity: currentIdentity,
         destinationIdentity: recipient.trim(),
-        amount: selectedAsset ? QX_TRANSFER_ASSET_FEE : parsedAmount,
+        amount: parsedAmount,
         quImpact: selectedAsset ? QX_TRANSFER_ASSET_FEE : parsedAmount,
         inputType: selectedAsset ? QX_TRANSFER_ASSET_INPUT_TYPE : 0,
+        tokenKey: selectedAsset ? `${selectedAsset.issuerIdentity}-${selectedAsset.name}` : 'qu',
         targetTick: Number(result.targetTick),
       })
       if (resendFromFailedHash) {

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import { toast } from 'sonner'
 import { useBalance, useSdk, useSend } from '@qubic-labs/react'
@@ -42,6 +42,7 @@ const formatUsd = (value: number) =>
 const Transfer = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
   usePendingTransactionsVersion()
   const [currentIdentity, setCurrentIdentity] = useState(getCurrentIdentity())
   const [isWatchOnly, setIsWatchOnly] = useState(() => isWatchOnlyIdentity(getCurrentIdentity()))
@@ -83,9 +84,9 @@ const Transfer = () => {
       : (parsedAssets.find((a) => `${a.issuerIdentity}-${a.name}` === selectedToken) ?? null)
   const parsedAmount = parseAmount(amount)
   const currentTick = latestStats.data?.data?.currentTick
-  const pendingOutgoingDebit = getPendingOutgoingDebit(currentIdentity, currentTick)
-  const hasPendingOutgoing =
-    getPendingTransactionsForIdentity(currentIdentity, currentTick).length > 0
+  const pendingForIdentity = getPendingTransactionsForIdentity(currentIdentity)
+  const pendingOutgoingDebit = getPendingOutgoingDebit(currentIdentity)
+  const hasPendingOutgoing = pendingForIdentity.some((tx) => tx.status === 'pending')
   const onChainQuBalance = normalizeBalance(balance.data?.balance)
   const effectiveQuBalance =
     onChainQuBalance > pendingOutgoingDebit ? onChainQuBalance - pendingOutgoingDebit : 0n
@@ -119,6 +120,27 @@ const Transfer = () => {
       window.removeEventListener('wallet-account-updated', refreshAccount)
     }
   }, [])
+
+  useEffect(() => {
+    const prefillRecipient = searchParams.get('recipient')?.trim()
+    const prefillAmount = searchParams.get('amount')?.trim()
+    let didPrefill = false
+
+    if (prefillRecipient) {
+      setRecipient(prefillRecipient.toUpperCase())
+      didPrefill = true
+    }
+    if (prefillAmount && /^\d+$/.test(prefillAmount)) {
+      setAmount(prefillAmount)
+      didPrefill = true
+    }
+
+    if (didPrefill) {
+      setErrors({})
+      setErrorMessage('')
+      setSearchParams({}, { replace: true })
+    }
+  }, [searchParams, setSearchParams])
 
   useEffect(() => {
     if (selectedToken === 'qu') return

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -49,6 +49,10 @@ const Transfer = () => {
     const value = (searchParams.get('amount') ?? '').trim()
     return /^\d+$/.test(value) ? value : ''
   })()
+  const initialPrefillInputType = (() => {
+    const value = Number.parseInt((searchParams.get('inputType') ?? '').trim(), 10)
+    return Number.isFinite(value) ? value : 0
+  })()
   const resendFromFailedHash = (searchParams.get('failedHash') ?? '').trim()
   usePendingTransactionsVersion()
   const [currentIdentity, setCurrentIdentity] = useState(getCurrentIdentity())
@@ -74,6 +78,12 @@ const Transfer = () => {
   const [isManualTargetTickEnabled, setIsManualTargetTickEnabled] = useState(false)
   const [manualTargetTick, setManualTargetTick] = useState('')
   const seedRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!resendFromFailedHash) return
+    if (initialPrefillInputType === 0) return
+    setErrorMessage(t('transfer.errors.resendUnsupported'))
+  }, [initialPrefillInputType, resendFromFailedHash, t])
 
   const parsedAssets = aggregateAssets(ownedAssets.data ?? {})
   const filteredVaultRecipients = useMemo(


### PR DESCRIPTION
this pr fixes pending transactions that were never added to the tickchain and stayed pending forever.

- added status to pending tx model: pending | failed

- updated pending resolver logic:
  - confirmed hash from api -> remove pending tx
  - archiver processed tick > target tick and hash not found -> mark as failed
  - otherwise keep as pending

- used archiver progress for resolution:
  - validForTick from transaction pages
  - useLastProcessedTick on tx details flow

- history/home now render local pending + failed entries at the top, separate from paginated api results
- added distinct failed styling (separate from amber pending)
- added resend flow for failed tx (opens transfer with prefilled recipient + amount)
- fixed transfer prefill persistence from query params (no lost values on navigation/remount)
- after successful resend, original failed local entry is removed
- added manual delete action for failed entries on home/history
- added i18n keys:
  - history.failed
  - history.resend
  - history.deleteFailed