### PR TITLE
fix: remove pending transaction blocking

### DIFF
--- a/src/components/pages/home/balance-card.tsx
+++ b/src/components/pages/home/balance-card.tsx
@@ -37,7 +37,6 @@ const setCachedBalance = (identity: string, value: bigint) => {
 type BalanceCardProps = {
   balance: ReturnType<typeof useBalance>
   identity: string
-  pendingDebit: bigint
   networkMeta: {
     tick: string | number
     epoch: string | number
@@ -45,7 +44,7 @@ type BalanceCardProps = {
   }
 }
 
-const BalanceCard = ({ balance, identity, pendingDebit, networkMeta }: BalanceCardProps) => {
+const BalanceCard = ({ balance, identity, networkMeta }: BalanceCardProps) => {
   const { t } = useTranslation()
   const [cachedBalance, setCachedBalanceState] = useState<bigint | null>(() =>
     getCachedBalance(identity),
@@ -81,9 +80,7 @@ const BalanceCard = ({ balance, identity, pendingDebit, networkMeta }: BalanceCa
     return <div className="text-sm text-destructive">{balance.error.message}</div>
   }
 
-  const effectiveBalance = normalized > pendingDebit ? normalized - pendingDebit : 0n
-  const pendingActive = pendingDebit > 0n
-  const displayValue = effectiveBalance
+  const displayValue = normalized
 
   return (
     <div className="space-y-3 text-center">
@@ -100,11 +97,6 @@ const BalanceCard = ({ balance, identity, pendingDebit, networkMeta }: BalanceCa
       <div className="text-[11px] text-muted-foreground">
         {networkMeta.price} / {networkMeta.tick} / {networkMeta.epoch}
       </div>
-      {pendingActive && (
-        <div className="text-[11px] text-amber-700 dark:text-amber-300">
-          -{formatBalanceCompact(pendingDebit)} {t('home.status.pending').toLowerCase()}
-        </div>
-      )}
     </div>
   )
 }

--- a/src/components/pages/home/transactions-preview.tsx
+++ b/src/components/pages/home/transactions-preview.tsx
@@ -45,7 +45,7 @@ const TransactionsPreview = ({
 }: TransactionsPreviewProps) => {
   const { t } = useTranslation()
 
-  const { pendingTop, failedTop, recentChain } = useMemo(() => {
+  const { unconfirmedTop, unconfirmedOverflow, recentChain } = useMemo(() => {
     const items = transactions.data?.pages.flatMap((page) => page.transactions) ?? []
     const pendingItems: PreviewTransaction[] = pendingTransactions.map((tx) => ({
       hash: tx.hash,
@@ -59,13 +59,16 @@ const TransactionsPreview = ({
       status: tx.status,
     }))
     const pendingHashes = new Set(pendingItems.map((tx) => tx.hash.toLowerCase()))
-    const pendingTop = pendingItems.filter((tx) => tx.status === 'pending')
-    const failedTop = pendingItems.filter((tx) => tx.status === 'failed')
+    const allUnconfirmed = pendingItems.filter(
+      (tx) => tx.status === 'pending' || tx.status === 'failed',
+    )
+    const unconfirmedTop = allUnconfirmed.slice(0, 3)
+    const unconfirmedOverflow = allUnconfirmed.length - unconfirmedTop.length
     const recentChain: PreviewTransaction[] = items
       .filter((tx) => !pendingHashes.has(tx.hash.toLowerCase()))
       .slice(0, 3)
 
-    return { pendingTop, failedTop, recentChain }
+    return { unconfirmedTop, unconfirmedOverflow, recentChain }
   }, [transactions.data, pendingTransactions])
 
   const renderRow = (tx: PreviewTransaction) => {
@@ -204,7 +207,7 @@ const TransactionsPreview = ({
     return <div className="text-xs text-destructive">{transactions.error.message}</div>
   }
 
-  if (pendingTop.length === 0 && failedTop.length === 0 && recentChain.length === 0) {
+  if (unconfirmedTop.length === 0 && recentChain.length === 0) {
     return (
       <div className="flex items-center gap-3 rounded-lg border border-dashed border-border/60 bg-muted/20 px-3 py-3 text-xs text-muted-foreground">
         <div className="flex h-9 w-9 items-center justify-center rounded-full bg-muted/40 text-muted-foreground">
@@ -220,25 +223,29 @@ const TransactionsPreview = ({
 
   return (
     <div className="w-full space-y-2 text-left">
-      {pendingTop.length > 0 && (
+      {unconfirmedTop.length > 0 && (
         <div className="space-y-2">
           <div className="text-[11px] font-semibold uppercase text-muted-foreground/70">
-            {t('history.pending')}
+            {t('history.unconfirmed')}
           </div>
-          {pendingTop.map((tx) => renderRow(tx))}
+          {unconfirmedTop.map((tx) => renderRow(tx))}
+          {unconfirmedOverflow > 0 && (
+            <button
+              type="button"
+              className="w-full cursor-pointer text-center text-[11px] text-muted-foreground transition-colors hover:text-foreground"
+              onClick={onViewMore}
+            >
+              {t('history.unconfirmedMore', { count: unconfirmedOverflow })}
+            </button>
+          )}
         </div>
       )}
-      {failedTop.length > 0 && (
-        <div className="space-y-2">
-          <div className="text-[11px] font-semibold uppercase text-muted-foreground/70">
-            {t('history.failed')}
-          </div>
-          {failedTop.map((tx) => renderRow(tx))}
-        </div>
-      )}
-      {(pendingTop.length > 0 || failedTop.length > 0) && recentChain.length > 0 && (
-        <div className="pt-1">
+      {unconfirmedTop.length > 0 && recentChain.length > 0 && (
+        <div className="space-y-2 pt-1">
           <div className="h-px w-full bg-border/40" />
+          <div className="text-[11px] font-semibold uppercase text-muted-foreground/70">
+            {t('history.confirmed')}
+          </div>
         </div>
       )}
       {recentChain.map((tx) => renderRow(tx))}

--- a/src/components/pages/transfer/transfer-form.tsx
+++ b/src/components/pages/transfer/transfer-form.tsx
@@ -22,7 +22,6 @@ type TransferFormProps = {
   manualTargetTick: string
   isManualTargetTickEnabled: boolean
   currentTick?: number
-  hasPendingOutgoing: boolean
   onTokenChange: (value: string) => void
   onSelectVaultRecipient: (identity: string) => void
   onRecipientChange: (value: string) => void
@@ -52,7 +51,6 @@ const TransferForm = ({
   manualTargetTick,
   isManualTargetTickEnabled,
   currentTick,
-  hasPendingOutgoing,
   onTokenChange,
   onSelectVaultRecipient,
   onRecipientChange,
@@ -124,7 +122,7 @@ const TransferForm = ({
                 placeholder="0"
                 value={amount}
                 onChange={(e) => onAmountChange(e.target.value.replace(/[^\d,]/g, ''))}
-                disabled={isWatchOnly || hasPendingOutgoing}
+                disabled={isWatchOnly}
                 className={`h-auto border-0 bg-transparent px-0 py-0 text-4xl font-semibold tracking-tight shadow-none ring-0 focus-visible:ring-0 ${errors.amount ? 'text-destructive' : ''}`}
               />
             </div>
@@ -137,7 +135,7 @@ const TransferForm = ({
                     : 'border-border/60 text-muted-foreground hover:border-primary/40 hover:text-foreground'
                 }`}
                 onClick={() => onTokenChange('qu')}
-                disabled={isWatchOnly || hasPendingOutgoing}
+                disabled={isWatchOnly}
               >
                 QU
               </button>
@@ -154,7 +152,7 @@ const TransferForm = ({
                         : 'border-border/60 text-muted-foreground hover:border-primary/40 hover:text-foreground'
                     }`}
                     onClick={() => onTokenChange(tokenValue)}
-                    disabled={isWatchOnly || hasPendingOutgoing}
+                    disabled={isWatchOnly}
                   >
                     {asset.name}
                   </button>
@@ -167,7 +165,7 @@ const TransferForm = ({
                   key={`amount-ratio-${ratio}`}
                   type="button"
                   className="cursor-pointer rounded-md border border-border/60 px-2 py-1 text-[11px] text-muted-foreground transition-colors hover:border-primary/40 hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
-                  disabled={isWatchOnly || hasPendingOutgoing || availableUnits <= 0n}
+                  disabled={isWatchOnly || availableUnits <= 0n}
                   onClick={() => setAmountByRatio(ratio)}
                 >
                   {ratio}%
@@ -211,7 +209,7 @@ const TransferForm = ({
                   }
                 }}
                 className={`font-mono text-xs ${errors.recipient ? 'border-destructive' : ''}`}
-                disabled={isWatchOnly || hasPendingOutgoing}
+                disabled={isWatchOnly}
               />
 
               {vaultRecipients.length > 0 && isRecipientPickerOpen && (
@@ -283,7 +281,7 @@ const TransferForm = ({
                       ? 'border-primary/60 bg-primary/10 text-foreground'
                       : 'border-border/60 text-muted-foreground hover:border-primary/40 hover:text-foreground'
                   }`}
-                  disabled={isWatchOnly || hasPendingOutgoing}
+                  disabled={isWatchOnly}
                   onClick={() => onTargetTickOffsetChange(offset)}
                 >
                   +{offset}
@@ -296,7 +294,7 @@ const TransferForm = ({
                     ? 'border-primary/60 bg-primary/10 text-foreground'
                     : 'border-border/60 text-muted-foreground hover:border-primary/40 hover:text-foreground'
                 }`}
-                disabled={isWatchOnly || hasPendingOutgoing}
+                disabled={isWatchOnly}
                 onClick={onManualTargetTickToggle}
               >
                 {t('transfer.form.targetTickOffsetManual')}
@@ -313,7 +311,7 @@ const TransferForm = ({
                     onManualTargetTickChange(event.target.value)
                   }}
                   className="h-10 w-full"
-                  disabled={isWatchOnly || hasPendingOutgoing}
+                  disabled={isWatchOnly}
                   placeholder={t('transfer.form.targetTickManualPlaceholder')}
                 />
                 <div className="text-[11px] text-muted-foreground">
@@ -333,20 +331,13 @@ const TransferForm = ({
             <span>{t('transfer.errors.watchOnly')}</span>
           </div>
         )}
-        {hasPendingOutgoing && (
-          <div className="flex items-start gap-2 text-xs text-amber-700 dark:text-amber-300">
-            <RouteIcon className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-            <span>{t('transfer.errors.pendingOutgoing')}</span>
-          </div>
-        )}
-
         {errorMessage && <p className="text-sm text-destructive">{errorMessage}</p>}
 
         <Button
           onClick={onContinue}
           size="lg"
           className="w-full"
-          disabled={isWatchOnly || hasPendingOutgoing || !recipient.trim() || !amount.trim()}
+          disabled={isWatchOnly || !recipient.trim() || !amount.trim()}
         >
           <SendIcon className="mr-2 h-4 w-4" />
           {t('transfer.actions.continue')}

--- a/src/lib/pending-transactions.ts
+++ b/src/lib/pending-transactions.ts
@@ -8,7 +8,6 @@ export type PendingTransaction = {
   sourceIdentity: string
   destinationIdentity?: string
   amount?: bigint
-  quImpact?: bigint
   inputType?: number
   tokenKey?: string
   targetTick: number
@@ -21,7 +20,6 @@ type SerializedPendingTransaction = {
   sourceIdentity: string
   destinationIdentity?: string
   amount?: string
-  quImpact?: string
   inputType?: number
   tokenKey?: string
   targetTick: number
@@ -71,7 +69,6 @@ const toSerialized = (pending: PendingTransaction): SerializedPendingTransaction
   sourceIdentity: pending.sourceIdentity,
   destinationIdentity: pending.destinationIdentity,
   amount: pending.amount?.toString(),
-  quImpact: pending.quImpact?.toString(),
   inputType: pending.inputType,
   tokenKey: pending.tokenKey,
   targetTick: pending.targetTick,
@@ -91,7 +88,6 @@ const fromSerialized = (value: unknown): PendingTransaction | null => {
       sourceIdentity: data.sourceIdentity,
       destinationIdentity: data.destinationIdentity,
       amount: data.amount ? BigInt(data.amount) : undefined,
-      quImpact: data.quImpact ? BigInt(data.quImpact) : undefined,
       inputType: data.inputType,
       tokenKey: data.tokenKey,
       targetTick: data.targetTick,
@@ -160,7 +156,6 @@ export const addPendingTransaction = (pending: {
   sourceIdentity: string
   destinationIdentity?: string
   amount?: bigint
-  quImpact?: bigint
   inputType?: number
   tokenKey?: string
   targetTick: number
@@ -217,15 +212,6 @@ export const getPendingTransactionsForIdentity = (identity: string) => {
     if (a.status === b.status) return b.createdAt - a.createdAt
     return a.status === 'pending' ? -1 : 1
   })
-}
-
-export const getPendingOutgoingDebit = (identity: string) => {
-  const pending = getPendingTransactionsForIdentity(identity)
-  return pending.reduce((sum, tx) => {
-    if (tx.status !== 'pending') return sum
-    const debit = tx.quImpact ?? tx.amount ?? 0n
-    return sum + (debit > 0n ? debit : 0n)
-  }, 0n)
 }
 
 export const canResendPendingTransaction = (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -67,8 +67,7 @@
       "description": "Sending is disabled for this address."
     },
     "status": {
-      "syncing": "Syncing",
-      "pending": "Pending"
+      "syncing": "Syncing"
     },
     "accounts": {
       "title": "Accounts",
@@ -242,6 +241,9 @@
     "tick": "Tick",
     "type": "Type",
     "pending": "Pending",
+    "unconfirmed": "Unconfirmed",
+    "unconfirmedMore": "+{{count}} more unconfirmed",
+    "confirmed": "Confirmed",
     "failed": "Failed",
     "resend": "Resend",
     "deleteFailed": "Delete failed transaction",
@@ -354,7 +356,6 @@
       "networkError": "Network error. Please retry.",
       "broadcastFailed": "Failed to broadcast transaction.",
       "watchOnly": "Watch-only accounts cannot send transfers.",
-      "pendingOutgoing": "A previous outgoing transfer is still pending. Please wait for confirmation.",
       "generic": "Transfer failed. Please retry."
     }
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -67,8 +67,7 @@
       "description": "El envío está deshabilitado para esta dirección."
     },
     "status": {
-      "syncing": "Sincronizando",
-      "pending": "Pendiente"
+      "syncing": "Sincronizando"
     },
     "accounts": {
       "title": "Cuentas",
@@ -242,6 +241,9 @@
     "tick": "Tick",
     "type": "Tipo",
     "pending": "Pendiente",
+    "unconfirmed": "Sin confirmar",
+    "unconfirmedMore": "+{{count}} más sin confirmar",
+    "confirmed": "Confirmadas",
     "failed": "Fallida",
     "resend": "Reenviar",
     "deleteFailed": "Eliminar transacción fallida",
@@ -354,7 +356,6 @@
       "networkError": "Error de red. Intenta de nuevo.",
       "broadcastFailed": "Fallo al transmitir la transacción.",
       "watchOnly": "Las cuentas de solo lectura no pueden enviar transferencias.",
-      "pendingOutgoing": "Hay una transferencia saliente pendiente. Espera su confirmación antes de enviar otra.",
       "generic": "Transferencia fallida. Intenta de nuevo."
     }
   },

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -18,7 +18,6 @@ import BalanceCard from '@/components/pages/home/balance-card'
 import TransactionsPreview from '@/components/pages/home/transactions-preview'
 import {
   getArchiverProcessedTick,
-  getPendingOutgoingDebit,
   PENDING_SETTLED_EVENT,
   getPendingTransactionsForIdentity,
   resolvePendingTransactions,
@@ -80,8 +79,6 @@ const Home = () => {
   const hasVirtualTick = virtualTick !== null
   const tickValue = virtualTick ?? currentTickFromRpc ?? '--'
   const pendingForIdentity = getPendingTransactionsForIdentity(identity)
-  const pendingOutgoingDebit = getPendingOutgoingDebit(identity)
-  const hasPendingOutgoing = pendingForIdentity.some((tx) => tx.status === 'pending')
   const epochValue = latestStats.data?.data?.epoch ?? '--'
   const pricePerBValue = latestStats.data?.data?.price
     ? `$${(latestStats.data.data.price * 1_000_000_000).toFixed(2)}`
@@ -263,7 +260,6 @@ const Home = () => {
               <BalanceCard
                 balance={balance}
                 identity={identity}
-                pendingDebit={pendingOutgoingDebit}
                 networkMeta={{ tick: tickValue, epoch: epochValue, price: pricePerBValue }}
               />
             </div>
@@ -283,8 +279,6 @@ const Home = () => {
                 size="sm"
                 className="h-12 w-full gap-2 rounded-md bg-primary/10 text-primary hover:bg-primary/20"
                 onClick={() => navigate('/transfer')}
-                disabled={hasPendingOutgoing}
-                title={hasPendingOutgoing ? t('transfer.errors.pendingOutgoing') : undefined}
               >
                 <SendIcon className="h-4 w-4" />
                 {t('home.actions.send')}

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -13,13 +13,7 @@ import {
   QX_TRANSFER_ASSET_INPUT_TYPE,
   buildAssetTransferPayload,
 } from '@/lib/qx'
-import {
-  addPendingTransaction,
-  getPendingOutgoingDebit,
-  getPendingTransactionsForIdentity,
-  PENDING_SETTLED_EVENT,
-  usePendingTransactionsVersion,
-} from '@/lib/pending-transactions'
+import { addPendingTransaction, PENDING_SETTLED_EVENT } from '@/lib/pending-transactions'
 import { isWalletLocked } from '@/lib/lock'
 import { useLatestStats } from '@/lib/network-stats'
 import ConfirmationDrawer from '@/components/pages/transfer/confirmation-drawer'
@@ -50,7 +44,6 @@ const Transfer = () => {
     return /^\d+$/.test(value) ? value : ''
   })()
   const initialPrefillToken = (searchParams.get('token') ?? 'qu').trim()
-  usePendingTransactionsVersion()
   const [currentIdentity, setCurrentIdentity] = useState(getCurrentIdentity())
   const [isWatchOnly, setIsWatchOnly] = useState(() => isWatchOnlyIdentity(getCurrentIdentity()))
   const [vaultRecipients, setVaultRecipients] = useState(() => getCachedAccounts())
@@ -91,12 +84,7 @@ const Transfer = () => {
       : (parsedAssets.find((a) => `${a.issuerIdentity}-${a.name}` === selectedToken) ?? null)
   const parsedAmount = parseAmount(amount)
   const currentTick = latestStats.data?.data?.currentTick
-  const pendingForIdentity = getPendingTransactionsForIdentity(currentIdentity)
-  const pendingOutgoingDebit = getPendingOutgoingDebit(currentIdentity)
-  const hasPendingOutgoing = pendingForIdentity.some((tx) => tx.status === 'pending')
   const onChainQuBalance = normalizeBalance(balance.data?.balance)
-  const effectiveQuBalance =
-    onChainQuBalance > pendingOutgoingDebit ? onChainQuBalance - pendingOutgoingDebit : 0n
   const usdEstimate = useMemo(() => {
     if (selectedAsset) return '--'
     const usdPricePerQus = latestStats.data?.data?.price
@@ -137,13 +125,6 @@ const Transfer = () => {
       setSelectedToken('qu')
     }
   }, [parsedAssets, selectedToken])
-
-  useEffect(() => {
-    if (hasPendingOutgoing) return
-    if (errorMessage === t('transfer.errors.pendingOutgoing')) {
-      setErrorMessage('')
-    }
-  }, [errorMessage, hasPendingOutgoing, t])
 
   useEffect(() => {
     const handlePendingSettled = () => {
@@ -193,13 +174,13 @@ const Transfer = () => {
         if (parsedAmount > assetBalance) {
           newErrors.amount = t('transfer.validation.amountExceedsBalance')
         }
-        if (effectiveQuBalance < QX_TRANSFER_ASSET_FEE) {
+        if (onChainQuBalance < QX_TRANSFER_ASSET_FEE) {
           newErrors.amount = t('transfer.validation.insufficientQuForFee', { fee: '100' })
         }
       } else if (balance.isLoading) {
         newErrors.amount = t('transfer.validation.balanceLoading')
       } else {
-        if (parsedAmount > effectiveQuBalance) {
+        if (parsedAmount > onChainQuBalance) {
           newErrors.amount = t('transfer.validation.amountExceedsBalance')
         }
       }
@@ -227,10 +208,6 @@ const Transfer = () => {
   const handleContinue = () => {
     if (isWatchOnly) {
       setErrorMessage(t('transfer.errors.watchOnly'))
-      return
-    }
-    if (hasPendingOutgoing) {
-      setErrorMessage(t('transfer.errors.pendingOutgoing'))
       return
     }
     if (validateForm()) {
@@ -326,7 +303,6 @@ const Transfer = () => {
         sourceIdentity: currentIdentity,
         destinationIdentity: recipient.trim(),
         amount: parsedAmount,
-        quImpact: selectedAsset ? QX_TRANSFER_ASSET_FEE : parsedAmount,
         inputType: selectedAsset ? QX_TRANSFER_ASSET_INPUT_TYPE : 0,
         tokenKey: selectedAsset ? `${selectedAsset.issuerIdentity}-${selectedAsset.name}` : 'qu',
         targetTick: Number(result.targetTick),
@@ -478,7 +454,6 @@ const Transfer = () => {
         manualTargetTick={manualTargetTick}
         isManualTargetTickEnabled={isManualTargetTickEnabled}
         currentTick={currentTick}
-        hasPendingOutgoing={hasPendingOutgoing}
         usdEstimate={usdEstimate}
         onTokenChange={handleTokenChange}
         onSelectVaultRecipient={handleSelectVaultRecipient}
@@ -487,7 +462,7 @@ const Transfer = () => {
         onTargetTickOffsetChange={handleTargetTickOffsetChange}
         onManualTargetTickChange={handleManualTargetTickChange}
         onManualTargetTickToggle={handleManualTargetTickToggle}
-        quBalance={effectiveQuBalance}
+        quBalance={onChainQuBalance}
         onContinue={handleContinue}
         quickTargetTickOffsets={QUICK_TARGET_TICK_OFFSETS}
       />


### PR DESCRIPTION
- Remove outdated logic that blocked sending new transactions while one was pending (no longer a network limitation, see https://docs.qubic.org/developers/ticks-and-concurrency)
- Remove `getPendingOutgoingDebit` function and `quImpact` field from pending transaction model
- Remove `pendingDebit` display from balance card and `hasPendingOutgoing` checks from transfer form
- Merge pending and failed transactions into a single "Unconfirmed" group on the home page, capped at 3 with overflow link
- Add "Confirmed" section header when unconfirmed items are present
- Clean up unused translation keys and code