### PR TITLE
fix(import): reject vault files exceeding 100 KB

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -429,6 +429,7 @@
         "importing": "Importing..."
       },
       "errors": {
+        "fileTooLarge": "The selected file is too large to be a valid vault file.",
         "selectFile": "Select a vault file.",
         "passphraseRequired": "Passphrase is required.",
         "importFailed": "Failed to import web wallet vault.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -429,6 +429,7 @@
         "importing": "Importando..."
       },
       "errors": {
+        "fileTooLarge": "El archivo seleccionado es demasiado grande para ser un vault válido.",
         "selectFile": "Selecciona un archivo vault.",
         "passphraseRequired": "Se requiere contraseña.",
         "importFailed": "No se pudo importar el vault de la billetera web.",

--- a/src/pages/onboarding/import-vault.tsx
+++ b/src/pages/onboarding/import-vault.tsx
@@ -14,6 +14,7 @@ import { getWatchOnlyAccounts, saveCachedAccounts, saveWatchOnlyAccounts } from 
 import FlowHeader from '@/components/onboarding/flow-header'
 
 const TOTAL_STEPS = 3
+const MAX_VAULT_FILE_SIZE = 102_400
 
 const ImportVault = () => {
   const navigate = useNavigate()
@@ -50,6 +51,11 @@ const ImportVault = () => {
   }
 
   const handleFileSelect = (selected: File | null) => {
+    if (selected && selected.size > MAX_VAULT_FILE_SIZE) {
+      setFile(null)
+      setStatus(t('onboarding.importVault.errors.fileTooLarge'))
+      return
+    }
     setFile(selected)
     setStatus(null)
   }


### PR DESCRIPTION
- Add a 100 KB file size limit when importing vault files
- Vault files are typically under 20 KB even with many accounts, so anything larger is not a valid vault
- Prevents the extension from freezing if a user accidentally selects a large file
- Error message is localized in English and Spanish