### PR TITLE
feat(ui): remove accounts tab from nav bar and improve settings layout

### DIFF
--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -177,9 +177,21 @@ const AppHeader = ({
             </button>
           </PopoverTrigger>
           <PopoverContent align="start" className="w-72 p-3">
-            <div className="flex items-center gap-2 text-xs font-semibold text-muted-foreground">
-              <UsersIcon className="h-4 w-4" />
-              {t('home.accounts.title')}
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 text-xs font-semibold text-muted-foreground">
+                <UsersIcon className="h-4 w-4" />
+                {t('home.accounts.title')}
+              </div>
+              <button
+                type="button"
+                className="flex h-6 w-6 items-center justify-center rounded-md bg-primary/10 text-primary transition hover:bg-primary/20"
+                onClick={() => {
+                  setIsMenuOpen(false)
+                  navigate('/accounts', { state: { openAdd: true } })
+                }}
+              >
+                <PlusIcon className="h-3.5 w-3.5" />
+              </button>
             </div>
             <div className="mt-3 space-y-2">
               {accounts.length === 0 && (
@@ -219,26 +231,6 @@ const AppHeader = ({
                       </div>
                     </button>
                   ))}
-                  <button
-                    type="button"
-                    className="mt-2 flex w-full items-center gap-2 border-t border-border/40 px-2 pt-3 text-left transition hover:opacity-80"
-                    onClick={() => {
-                      setIsMenuOpen(false)
-                      navigate('/accounts', { state: { openAdd: true } })
-                    }}
-                  >
-                    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted/30">
-                      <PlusIcon className="h-3.5 w-3.5 text-muted-foreground" />
-                    </div>
-                    <div className="flex flex-col">
-                      <span className="text-xs font-semibold text-foreground">
-                        {t('accounts.manage.addTitle')}
-                      </span>
-                      <span className="text-[11px] text-muted-foreground">
-                        {t('accounts.manage.addNewDesc')}
-                      </span>
-                    </div>
-                  </button>
                 </div>
               )}
             </div>

--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { NavLink, useLocation } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { motion } from 'framer-motion'
-import { ArrowLeftRightIcon, HistoryIcon, HomeIcon, SettingsIcon, UsersIcon } from 'lucide-react'
+import { ArrowLeftRightIcon, HistoryIcon, HomeIcon, SettingsIcon } from 'lucide-react'
 import AppHeader from '@/components/app-header'
 import { getWatchOnlyAccounts } from '@/lib/accounts'
 
@@ -103,12 +103,6 @@ const AppShell = ({
         to: '/transfer',
         label: t('nav.transfer'),
         icon: <ArrowLeftRightIcon className="size-5" />,
-      },
-      {
-        key: 'accounts',
-        to: '/accounts',
-        label: t('nav.accounts'),
-        icon: <UsersIcon className="size-5" />,
       },
       {
         key: 'settings',

--- a/src/components/pages/manage-accounts/account-list-item.tsx
+++ b/src/components/pages/manage-accounts/account-list-item.tsx
@@ -1,5 +1,6 @@
 import {
   CheckIcon,
+  EyeIcon,
   GripVerticalIcon,
   MoreHorizontalIcon,
   PencilIcon,
@@ -77,7 +78,8 @@ const AccountListItem = ({
           <div className="flex items-center gap-2">
             <span className="truncate text-sm font-semibold text-foreground">{account.name}</span>
             {account.watchOnly && (
-              <span className="inline-flex shrink-0 items-center rounded-full border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-200">
+              <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-200">
+                <EyeIcon className="h-2.5 w-2.5" />
                 {t('accounts.manage.watchOnly')}
               </span>
             )}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -109,7 +109,7 @@
       }
     },
     "categories": {
-      "general": "General",
+      "general": "Preferences",
       "generalDesc": "Language and theme preferences",
       "security": "Security",
       "securityDesc": "Password, auto-lock, and app reset",
@@ -123,7 +123,7 @@
       "aboutDesc": "App version and info"
     },
     "general": {
-      "title": "General",
+      "title": "Preferences",
       "back": "Settings"
     },
     "security": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -109,7 +109,7 @@
       }
     },
     "categories": {
-      "general": "General",
+      "general": "Preferencias",
       "generalDesc": "Preferencias de idioma y tema",
       "security": "Seguridad",
       "securityDesc": "Contraseña, bloqueo automático y restablecer",
@@ -123,7 +123,7 @@
       "aboutDesc": "Versión de la aplicación e información"
     },
     "general": {
-      "title": "General",
+      "title": "Preferencias",
       "back": "Configuración"
     },
     "security": {

--- a/src/pages/manage-accounts.tsx
+++ b/src/pages/manage-accounts.tsx
@@ -379,6 +379,13 @@ const ManageAccounts = () => {
             <h2 className="text-base font-semibold">{t('accounts.manage.title')}</h2>
             <p className="text-xs text-muted-foreground">{t('accounts.manage.subtitle')}</p>
           </div>
+          <button
+            type="button"
+            onClick={() => setAddOpen(true)}
+            className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary transition hover:bg-primary/20"
+          >
+            <PlusIcon className="h-4 w-4" />
+          </button>
         </div>
 
         <div className="space-y-2">
@@ -418,23 +425,6 @@ const ManageAccounts = () => {
               {t('accounts.manage.empty')}
             </div>
           )}
-          <button
-            type="button"
-            onClick={() => setAddOpen(true)}
-            className="flex w-full items-center gap-3 rounded-lg border border-dashed border-border/60 bg-muted/10 px-3 py-3 text-left text-sm text-muted-foreground transition hover:bg-muted/20"
-          >
-            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-muted/30 text-muted-foreground">
-              <PlusIcon className="h-4 w-4" />
-            </div>
-            <div className="flex flex-col">
-              <span className="text-sm font-semibold text-foreground">
-                {t('accounts.manage.addTitle')}
-              </span>
-              <span className="text-xs text-muted-foreground">
-                {t('accounts.manage.addNewDesc')}
-              </span>
-            </div>
-          </button>
           {status && <p className="text-xs text-destructive">{status}</p>}
         </div>
       </div>

--- a/src/pages/manage-accounts.tsx
+++ b/src/pages/manage-accounts.tsx
@@ -3,7 +3,7 @@ import { useLocation, useNavigate } from 'react-router-dom'
 import { useQueries } from '@tanstack/react-query'
 import { useSdk } from '@qubic-labs/react'
 import { VaultInvalidPassphraseError, VaultEntryNotFoundError } from '@qubic-labs/sdk'
-import { PlusIcon } from 'lucide-react'
+import { ArrowLeftIcon, PlusIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import {
   getAccountOrder,
@@ -366,6 +366,14 @@ const ManageAccounts = () => {
   return (
     <section className="flex min-h-full w-full justify-center pb-6 pt-4">
       <div className="flex w-full flex-col gap-4 px-4">
+        <button
+          type="button"
+          onClick={() => navigate('/settings')}
+          className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeftIcon className="h-4 w-4" />
+          {t('settings.general.back')}
+        </button>
         <div className="flex items-center justify-between gap-2">
           <div>
             <h2 className="text-base font-semibold">{t('accounts.manage.title')}</h2>

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -94,6 +94,13 @@ const Settings = () => {
 
   const categories = [
     {
+      key: 'accounts',
+      icon: UsersIcon,
+      label: t('settings.categories.accounts'),
+      description: t('settings.categories.accountsDesc'),
+      action: () => navigate('/accounts'),
+    },
+    {
       key: 'general',
       icon: SlidersHorizontalIcon,
       label: t('settings.categories.general'),
@@ -113,13 +120,6 @@ const Settings = () => {
       label: t('settings.categories.backup'),
       description: t('settings.categories.backupDesc'),
       action: () => setExportDrawerOpen(true),
-    },
-    {
-      key: 'accounts',
-      icon: UsersIcon,
-      label: t('settings.categories.accounts'),
-      description: t('settings.categories.accountsDesc'),
-      action: () => navigate('/accounts'),
     },
     {
       key: 'support',


### PR DESCRIPTION
Move account management from nav bar to settings page, simplifying navigation from 5 to 4 tabs. Rename "General" to "Preferences" and add eye icon to watch-only tag.