### PR TITLE
feat(dapp): add per-account permissions for connected dApps

### DIFF
--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -26,7 +26,9 @@ import {
 import {
   DAPP_CURRENT_ACCOUNT_KEY,
   DAPP_PERMISSIONS_KEY,
+  getDappCurrentAccount,
   getDappPermissions,
+  isAccountApprovedForOrigin,
 } from '@/lib/dapp/storage'
 
 chrome.runtime.onMessage.addListener((message: unknown, sender, sendResponse) => {
@@ -97,30 +99,17 @@ chrome.runtime.onMessage.addListener((message: unknown, sender, sendResponse) =>
   return true
 })
 
-type BroadcastEventOptions = {
-  targetOrigin?: string
-  onlyConnectedOrigins?: boolean
-}
-
-const broadcastEvent = async (event: DappEventMessage, options: BroadcastEventOptions = {}) => {
+const broadcastEvent = async (event: DappEventMessage, targetOrigin: string) => {
   const tabs = await chrome.tabs.query({})
-  const connectedOrigins = options.onlyConnectedOrigins ? await getDappPermissions() : null
-  const normalizedTargetOrigin = options.targetOrigin ? normalizeOrigin(options.targetOrigin) : null
+  const normalizedTargetOrigin = normalizeOrigin(targetOrigin)
 
   for (const tab of tabs) {
     if (!tab.id || !tab.url) continue
 
     const tabOrigin = getOriginFromUrl(tab.url)
     if (!tabOrigin) continue
-    const normalizedTabOrigin = normalizeOrigin(tabOrigin)
 
-    if (normalizedTargetOrigin && normalizedTabOrigin !== normalizedTargetOrigin) {
-      continue
-    }
-
-    if (connectedOrigins && !connectedOrigins[normalizedTabOrigin]) {
-      continue
-    }
+    if (normalizeOrigin(tabOrigin) !== normalizedTargetOrigin) continue
 
     try {
       await chrome.tabs.sendMessage(tab.id, {
@@ -133,20 +122,47 @@ const broadcastEvent = async (event: DappEventMessage, options: BroadcastEventOp
   }
 }
 
+const broadcastAccountChangedPerOrigin = async () => {
+  const newAccount = await getDappCurrentAccount()
+  const permissions = await getDappPermissions()
+  const tabs = await chrome.tabs.query({})
+
+  for (const tab of tabs) {
+    if (!tab.id || !tab.url) continue
+
+    const tabOrigin = getOriginFromUrl(tab.url)
+    if (!tabOrigin) continue
+    const normalizedTabOrigin = normalizeOrigin(tabOrigin)
+
+    const permission = permissions[normalizedTabOrigin]
+    if (!permission) continue
+
+    const isApproved =
+      newAccount &&
+      isAccountApprovedForOrigin(normalizedTabOrigin, permissions, newAccount.identity)
+    const eventPayload = isApproved ? newAccount : null
+
+    try {
+      await chrome.tabs.sendMessage(tab.id, {
+        type: RUNTIME_EVENT_TYPE,
+        payload: {
+          channel: DAPP_CHANNEL,
+          source: CONTENT_SOURCE,
+          event: 'accountChanged',
+          payload: eventPayload,
+        },
+      })
+    } catch {
+      // Ignore tabs without content script.
+    }
+  }
+}
+
 chrome.storage.onChanged.addListener((changes, areaName) => {
   if (areaName !== 'local') return
 
   if (changes[DAPP_CURRENT_ACCOUNT_KEY]) {
-    const payload = changes[DAPP_CURRENT_ACCOUNT_KEY].newValue
-    void broadcastEvent(
-      {
-        channel: DAPP_CHANNEL,
-        source: CONTENT_SOURCE,
-        event: 'accountChanged',
-        payload,
-      },
-      { onlyConnectedOrigins: true },
-    )
+    void broadcastAccountChangedPerOrigin()
   }
 
   if (changes[DAPP_PERMISSIONS_KEY]) {
@@ -161,7 +177,7 @@ chrome.storage.onChanged.addListener((changes, areaName) => {
           event: 'disconnect',
           payload: { origin },
         },
-        { targetOrigin: origin },
+        origin,
       )
     }
   }

--- a/src/lib/dapp/controller.ts
+++ b/src/lib/dapp/controller.ts
@@ -18,6 +18,7 @@ import {
   getDappCurrentAccount,
   getDappPendingRequests,
   getDappPermissions,
+  isAccountApprovedForOrigin,
   removeDappPermission,
   setDappPermissions,
 } from '@/lib/dapp/storage'
@@ -68,6 +69,19 @@ type DappSendTransactionParams = {
 const ensureConnected = (origin: string, permissions: DappPermissionsState) => {
   if (!permissions[origin]) {
     throw new DappProviderError('NOT_CONNECTED', 'Origin is not connected to wallet')
+  }
+}
+
+const ensureAccountApproved = (
+  origin: string,
+  permissions: DappPermissionsState,
+  account: DappCurrentAccount,
+) => {
+  if (!isAccountApprovedForOrigin(origin, permissions, account.identity)) {
+    throw new DappProviderError(
+      'NOT_CONNECTED',
+      'Active account is not approved for this origin. Call connect() first.',
+    )
   }
 }
 
@@ -143,8 +157,14 @@ const enqueueApprovalRequest = async (request: DappExecutionRequest) => {
 
 const connectOrigin = async (origin: string, requestId: string, session: string) => {
   const permissions = await getDappPermissions()
-  if (!permissions[origin]) {
-    const account = await getDappCurrentAccount()
+  const account = await getDappCurrentAccount()
+  const existingPermission = permissions[origin]
+
+  const needsApproval = account
+    ? !existingPermission || !isAccountApprovedForOrigin(origin, permissions, account.identity)
+    : !existingPermission
+
+  if (needsApproval) {
     await enqueueApprovalRequest({
       id: requestId,
       method: 'connect',
@@ -157,8 +177,6 @@ const connectOrigin = async (origin: string, requestId: string, session: string)
     return asRuntimePendingAck(requestId)
   }
 
-  permissions[origin] = { origin, connectedAt: Date.now() }
-  await setDappPermissions(permissions)
   return { connected: true as const, origin }
 }
 
@@ -170,7 +188,11 @@ const disconnectOrigin = async (origin: string) => {
 const getAccountForOrigin = async (origin: string) => {
   const permissions = await getDappPermissions()
   ensureConnected(origin, permissions)
-  return getDappCurrentAccount()
+  const account = await getDappCurrentAccount()
+  if (account && !isAccountApprovedForOrigin(origin, permissions, account.identity)) {
+    return null
+  }
+  return account
 }
 
 const requireCurrentAccount = async (): Promise<DappCurrentAccount> => {
@@ -196,8 +218,8 @@ const queueSigningApproval = async (
 ): Promise<DappRuntimePendingAck> => {
   const permissions = await getDappPermissions()
   ensureConnected(origin, permissions)
-
   const account = await requireCurrentAccount()
+  ensureAccountApproved(origin, permissions, account)
   await enqueueApprovalRequest({
     id: request.id,
     method: request.method === 'signMessage' ? 'signMessage' : 'signTransaction',
@@ -299,6 +321,7 @@ const queueSendTransactionApproval = async (
   const permissions = await getDappPermissions()
   ensureConnected(origin, permissions)
   const account = await requireCurrentAccount()
+  ensureAccountApproved(origin, permissions, account)
   const queuedParams = normalizeQueuedSendTransactionParams(request.params)
 
   await enqueueApprovalRequest({
@@ -326,9 +349,18 @@ const executeApprovedRequest = async (
         return asDappFailure(request.id, 'USER_REJECTED', 'Connection request was rejected')
       }
       const permissions = await getDappPermissions()
+      const currentAccount = await getDappCurrentAccount()
+      const existing = permissions[normalizedOrigin]
+      const previousIdentities = existing?.approvedIdentities ?? []
+      const identityToApprove = currentAccount?.identity
+      const approvedIdentities =
+        identityToApprove && !previousIdentities.includes(identityToApprove)
+          ? [...previousIdentities, identityToApprove]
+          : previousIdentities
       permissions[normalizedOrigin] = {
         origin: normalizedOrigin,
         connectedAt: Date.now(),
+        approvedIdentities,
       }
       await setDappPermissions(permissions)
       return asDappSuccess(request.id, { connected: true as const, origin: normalizedOrigin })
@@ -346,6 +378,7 @@ const executeApprovedRequest = async (
       const permissions = await getDappPermissions()
       ensureConnected(normalizedOrigin, permissions)
       const account = request.account
+      if (account) ensureAccountApproved(normalizedOrigin, permissions, account)
       if (!account?.identity) {
         throw new DappProviderError('NO_ACCOUNT', 'No active account is selected')
       }

--- a/src/lib/dapp/schemas.ts
+++ b/src/lib/dapp/schemas.ts
@@ -30,6 +30,7 @@ export const dappPendingRequestSchema = z.object({
 export const dappPermissionRecordSchema = z.object({
   origin: z.string().min(1),
   connectedAt: z.number().finite(),
+  approvedIdentities: z.array(z.string().min(1)).optional(),
 })
 
 export const dappPermissionsStateSchema = z.record(z.string(), dappPermissionRecordSchema)

--- a/src/lib/dapp/storage.ts
+++ b/src/lib/dapp/storage.ts
@@ -16,9 +16,20 @@ export const DAPP_REQUEST_RESULTS_KEY = 'dapp.requestResults.v1'
 export type DappPermissionRecord = Readonly<{
   origin: string
   connectedAt: number
+  approvedIdentities?: readonly string[]
 }>
 
 export type DappPermissionsState = Record<string, DappPermissionRecord>
+
+export const isAccountApprovedForOrigin = (
+  origin: string,
+  permissions: DappPermissionsState,
+  identity: string,
+): boolean => {
+  const permission = permissions[origin]
+  if (!permission?.approvedIdentities?.length) return true
+  return permission.approvedIdentities.includes(identity)
+}
 
 export type DappCurrentAccount = Readonly<{
   identity: string

--- a/src/pages/settings/connected-sites.tsx
+++ b/src/pages/settings/connected-sites.tsx
@@ -4,24 +4,24 @@ import { useNavigate } from 'react-router-dom'
 import { ArrowLeftIcon, Link2OffIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { getChromeApi } from '@/lib/dapp/chrome-api'
-import { DAPP_PERMISSIONS_KEY, getDappPermissions, removeDappPermission } from '@/lib/dapp/storage'
-
-type ConnectedSite = {
-  origin: string
-  connectedAt: number
-}
+import {
+  type DappPermissionRecord,
+  DAPP_PERMISSIONS_KEY,
+  getDappPermissions,
+  removeDappPermission,
+} from '@/lib/dapp/storage'
+import { truncateString } from '@/lib/utils'
 
 const ConnectedSites = () => {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const [sites, setSites] = useState<ConnectedSite[]>([])
+  const [sites, setSites] = useState<DappPermissionRecord[]>([])
+
   const [disconnectingOrigin, setDisconnectingOrigin] = useState('')
 
   const loadSites = useCallback(async () => {
     const permissions = await getDappPermissions()
-    const entries = Object.values(permissions)
-      .map((entry) => ({ origin: entry.origin, connectedAt: entry.connectedAt }))
-      .sort((a, b) => b.connectedAt - a.connectedAt)
+    const entries = Object.values(permissions).sort((a, b) => b.connectedAt - a.connectedAt)
     setSites(entries)
   }, [])
 
@@ -74,6 +74,11 @@ const ConnectedSites = () => {
               >
                 <div className="min-w-0 flex-1">
                   <p className="truncate text-sm font-medium text-foreground">{site.origin}</p>
+                  {site.approvedIdentities?.map((id) => (
+                    <p key={id} className="truncate font-mono text-xs text-muted-foreground">
+                      {truncateString(id)}
+                    </p>
+                  ))}
                   <p className="text-xs text-muted-foreground">
                     {t('settings.connectedSites.connectedAt', {
                       date: new Date(site.connectedAt).toLocaleString(),


### PR DESCRIPTION
Implement Phantom-style per-account approval model. When the user switches to an account that was not explicitly approved for a dApp, accountChanged fires with null instead of leaking the account identity. The dApp must call connect() again to request access.

- Add approvedIdentities array to permission records
- Gate signing/transaction requests for unapproved accounts
- Show approved identities in Connected Sites settings
- Backward compatible: legacy permissions without approvedIdentities are treated permissively until connect() upgrades them