### PR TITLE
feat(dapp): toast notifications and tx display improvements

### DIFF
--- a/src/components/dapp/dapp-approval-drawer.tsx
+++ b/src/components/dapp/dapp-approval-drawer.tsx
@@ -24,9 +24,10 @@ import {
 } from '@/lib/dapp/approval-preview'
 import { getChromeApi } from '@/lib/dapp/chrome-api'
 import { PasswordInput } from '@/components/ui/password-input'
-import { formatNumber, truncateString } from '@/lib/utils'
+import { formatIntegerLike, formatNumber, truncateString } from '@/lib/utils'
+import { NATIVE_TOKEN_SYMBOL } from '@/lib/config/constants'
 import AddressLabel from '@/components/address-label'
-import { useProcedureName } from '@/hooks/use-procedure-name'
+import { useTxTypeDescription } from '@/hooks/use-tx-type-description'
 import { isWalletLocked } from '@/lib/lock'
 import { validateVaultPassphrase } from '@/lib/vault'
 import { toast } from 'sonner'
@@ -90,7 +91,7 @@ const DappApprovalDrawer = () => {
     [current?.params],
   )
   const txSummary = useMemo(() => getApprovalTxSummary(current?.params), [current?.params])
-  const procedureName = useProcedureName(
+  const txTypeDescription = useTxTypeDescription(
     txSummary?.toIdentity ?? '',
     Number(txSummary?.inputType ?? 0),
   )
@@ -267,23 +268,23 @@ const DappApprovalDrawer = () => {
                   {txSummary.amount && (
                     <p className="text-xs text-muted-foreground">
                       {t('dapp.approval.txAmount')}:{' '}
-                      <span className="font-mono text-foreground">{txSummary.amount}</span>
+                      <span className="font-mono text-foreground">
+                        {formatIntegerLike(txSummary.amount)} {NATIVE_TOKEN_SYMBOL}
+                      </span>
                     </p>
                   )}
                   {txSummary.inputType && (
                     <p className="text-xs text-muted-foreground">
-                      {t('dapp.approval.txInputType')}:{' '}
-                      <span className="font-mono text-foreground">
-                        {procedureName
-                          ? `${txSummary.inputType} (${procedureName})`
-                          : txSummary.inputType}
-                      </span>
+                      {t('dapp.approval.txType')}:{' '}
+                      <span className="font-mono text-foreground">{txTypeDescription}</span>
                     </p>
                   )}
                   {txSummary.targetTick && (
                     <p className="text-xs text-muted-foreground">
                       {t('dapp.approval.txTargetTick')}:{' '}
-                      <span className="font-mono text-foreground">{txSummary.targetTick}</span>
+                      <span className="font-mono text-foreground">
+                        {formatNumber(Number(txSummary.targetTick))}
+                      </span>
                     </p>
                   )}
                   {txSummary.targetTickOffset && (

--- a/src/components/dapp/dapp-approval-drawer.tsx
+++ b/src/components/dapp/dapp-approval-drawer.tsx
@@ -24,11 +24,12 @@ import {
 } from '@/lib/dapp/approval-preview'
 import { getChromeApi } from '@/lib/dapp/chrome-api'
 import { PasswordInput } from '@/components/ui/password-input'
-import { truncateString } from '@/lib/utils'
+import { formatNumber, truncateString } from '@/lib/utils'
 import AddressLabel from '@/components/address-label'
 import { useProcedureName } from '@/hooks/use-procedure-name'
 import { isWalletLocked } from '@/lib/lock'
 import { validateVaultPassphrase } from '@/lib/vault'
+import { toast } from 'sonner'
 
 const DappApprovalDrawer = () => {
   const { t } = useTranslation()
@@ -139,7 +140,11 @@ const DappApprovalDrawer = () => {
     setLoading(true)
     setError('')
     try {
-      const ok = await new Promise<boolean>((resolve) => {
+      const result = await new Promise<{
+        ok?: boolean
+        executed?: boolean
+        targetTick?: number
+      }>((resolve) => {
         runtime.sendMessage(
           {
             type: RUNTIME_APPROVAL_DECISION_TYPE,
@@ -149,15 +154,33 @@ const DappApprovalDrawer = () => {
               passphrase: approved && requiresPassphrase ? normalizedPassphrase : undefined,
             },
           },
-          (response?: { ok?: boolean }) => {
-            resolve(Boolean(response?.ok))
+          (response?: { ok?: boolean; executed?: boolean; targetTick?: number }) => {
+            resolve(response ?? { ok: false })
           },
         )
       })
-      if (!ok) {
+      if (!result.ok) {
         setError(t('dapp.approval.errors.decisionFailed'))
         return
       }
+      if (approved && current.method === 'sendTransaction') {
+        if (result.executed === true) {
+          const isSimpleTransfer = txSummary?.inputType === '0' && Number(txSummary?.amount) > 0
+          const targetTick =
+            result.targetTick && Number.isFinite(result.targetTick)
+              ? formatNumber(result.targetTick)
+              : undefined
+          toast.success(
+            isSimpleTransfer ? t('transfer.success.title') : t('dapp.approval.txBroadcastSuccess'),
+            targetTick
+              ? { description: t('transaction.broadcastDescription', { targetTick }) }
+              : undefined,
+          )
+        } else if (result.executed === false) {
+          toast.error(t('transfer.errors.broadcastFailed'))
+        }
+      }
+
       setRequests((prev) => prev.filter((request) => request.id !== current.id))
       setPassphrase('')
 

--- a/src/components/dapp/dapp-approval-drawer.tsx
+++ b/src/components/dapp/dapp-approval-drawer.tsx
@@ -279,19 +279,11 @@ const DappApprovalDrawer = () => {
                       <span className="font-mono text-foreground">{txTypeDescription}</span>
                     </p>
                   )}
-                  {txSummary.targetTick && (
+                  {txSummary.targetTick && Number(txSummary.targetTick) > 0 && (
                     <p className="text-xs text-muted-foreground">
                       {t('dapp.approval.txTargetTick')}:{' '}
                       <span className="font-mono text-foreground">
                         {formatNumber(Number(txSummary.targetTick))}
-                      </span>
-                    </p>
-                  )}
-                  {txSummary.targetTickOffset && (
-                    <p className="text-xs text-muted-foreground">
-                      {t('dapp.approval.txTargetTickOffset')}:{' '}
-                      <span className="font-mono text-foreground">
-                        +{txSummary.targetTickOffset}
                       </span>
                     </p>
                   )}

--- a/src/components/pages/home/transactions-preview.tsx
+++ b/src/components/pages/home/transactions-preview.tsx
@@ -137,41 +137,43 @@ const TransactionsPreview = ({
             </span>
           </div>
         </div>
-        <span
-          className={`text-sm font-semibold ${
-            !isVisible
-              ? 'text-muted-foreground'
-              : isPending
-                ? 'text-amber-700 dark:text-amber-300'
-                : isFailed
-                  ? 'text-red-700 dark:text-red-300'
-                  : amountColorClass
-          }`}
-        >
-          {isVisible ? `${amountSign}${formatBalanceCompact(tx.amount)}` : HIDDEN_BALANCE}
-        </span>
-        {isFailed && (
-          <div className="ml-2 flex items-center gap-1">
-            {canResend && (
+        <div className="flex items-center gap-2">
+          <span
+            className={`text-sm font-semibold ${
+              !isVisible
+                ? 'text-muted-foreground'
+                : isPending
+                  ? 'text-amber-700 dark:text-amber-300'
+                  : isFailed
+                    ? 'text-red-700 dark:text-red-300'
+                    : amountColorClass
+            }`}
+          >
+            {isVisible ? `${amountSign}${formatBalanceCompact(tx.amount)}` : HIDDEN_BALANCE}
+          </span>
+          {isFailed && (
+            <div className="flex items-center gap-1">
+              {canResend && (
+                <button
+                  type="button"
+                  className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-primary hover:underline"
+                  onClick={() => onResend(tx.hash, tx.destination, tx.amount, tx.tokenKey)}
+                >
+                  {t('history.resend')}
+                </button>
+              )}
               <button
                 type="button"
-                className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-primary hover:underline"
-                onClick={() => onResend(tx.hash, tx.destination, tx.amount, tx.tokenKey)}
+                className="cursor-pointer text-muted-foreground transition-colors hover:text-foreground"
+                onClick={() => removePendingTransaction(tx.hash)}
+                aria-label={t('history.deleteFailed')}
+                title={t('history.deleteFailed')}
               >
-                {t('history.resend')}
+                <XIcon className="h-3.5 w-3.5" />
               </button>
-            )}
-            <button
-              type="button"
-              className="cursor-pointer text-muted-foreground transition-colors hover:text-foreground"
-              onClick={() => removePendingTransaction(tx.hash)}
-              aria-label={t('history.deleteFailed')}
-              title={t('history.deleteFailed')}
-            >
-              <XIcon className="h-3.5 w-3.5" />
-            </button>
-          </div>
-        )}
+            </div>
+          )}
+        </div>
         {!isFailed && (
           <button
             type="button"

--- a/src/extension/background.ts
+++ b/src/extension/background.ts
@@ -53,7 +53,13 @@ chrome.runtime.onMessage.addListener((message: unknown, sender, sendResponse) =>
     const payload = parsed.data.payload
 
     void handleDappApprovalDecision(payload)
-      .then((ok) => sendResponse({ ok }))
+      .then((result) => {
+        if (typeof result === 'object') {
+          sendResponse(result)
+        } else {
+          sendResponse({ ok: result })
+        }
+      })
       .catch(() => sendResponse({ ok: false }))
     return true
   }

--- a/src/hooks/use-tx-type-description.ts
+++ b/src/hooks/use-tx-type-description.ts
@@ -1,0 +1,11 @@
+import { useTranslation } from 'react-i18next'
+import { useProcedureName } from '@/hooks/use-procedure-name'
+
+export const useTxTypeDescription = (destination: string, inputType: number): string => {
+  const { t } = useTranslation()
+  const procedureName = useProcedureName(destination, inputType)
+
+  if (procedureName) return `${procedureName} (${inputType})`
+  if (inputType === 0) return `${t('transaction.txTypeTransfer')} (0)`
+  return String(inputType)
+}

--- a/src/lib/dapp/approval-preview.ts
+++ b/src/lib/dapp/approval-preview.ts
@@ -107,7 +107,7 @@ export const getApprovalTxSummary = (params: unknown): DappTxApprovalSummary | n
   const inputType =
     typeof record.inputType === 'string' || typeof record.inputType === 'number'
       ? `${record.inputType}`
-      : ''
+      : '0'
   const targetTick =
     typeof record.targetTick === 'string' || typeof record.targetTick === 'number'
       ? `${record.targetTick}`

--- a/src/lib/dapp/controller.ts
+++ b/src/lib/dapp/controller.ts
@@ -510,7 +510,20 @@ export const handleDappApprovalDecision = async (decision: DappApprovalDecision)
       const response = await executeApprovedRequest(claimedRequest, decision)
       await storeRequestResult(claimedRequest, response)
       await completeExecutionRequest(claimedRequest.id)
-      return true
+      const result =
+        response.ok && response.result && typeof response.result === 'object'
+          ? (response.result as Record<string, unknown>)
+          : null
+      return {
+        ok: true as const,
+        executed: true as const,
+        targetTick:
+          typeof result?.targetTick === 'number'
+            ? result.targetTick
+            : typeof result?.targetTick === 'string'
+              ? Number(result.targetTick)
+              : undefined,
+      }
     } catch (error) {
       const normalized = asProviderError(error, {
         code: 'INTERNAL_ERROR',
@@ -521,7 +534,7 @@ export const handleDappApprovalDecision = async (decision: DappApprovalDecision)
         asDappFailure(claimedRequest.id, normalized.code, normalized.message),
       )
       await completeExecutionRequest(claimedRequest.id)
-      return true
+      return { ok: true as const, executed: false as const }
     }
   } finally {
     processingApprovalDecisionIds.delete(decision.id)

--- a/src/lib/transaction-presentation.ts
+++ b/src/lib/transaction-presentation.ts
@@ -29,7 +29,11 @@ export const getTransactionPresentation = (tx: Transaction, identity: string, t:
   }
 
   const amountSign = tx.amount ? (isIncoming ? '+' : '-') : ''
-  const amountColorClass = !tx.amount || isIncoming ? 'text-primary' : 'text-[var(--destructive)]'
+  const amountColorClass = !tx.amount
+    ? 'text-muted-foreground'
+    : isIncoming
+      ? 'text-positive'
+      : 'text-[var(--destructive)]'
 
   return {
     isIncoming,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -50,6 +50,24 @@ export const formatNumber = (value: number | bigint): string => {
 }
 
 /**
+ * Format an integer-like value (number, bigint, or numeric string) for display.
+ * Returns '--' for null/undefined/non-finite values.
+ */
+export const formatIntegerLike = (value: unknown): string => {
+  if (value === null || value === undefined) return '--'
+  if (typeof value === 'bigint') return formatNumber(value)
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) return '--'
+    return formatNumber(Math.trunc(value))
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim()
+    if (/^-?\d+$/.test(normalized)) return formatNumber(BigInt(normalized))
+  }
+  return String(value)
+}
+
+/**
  * Format balance for display with full precision (standard notation)
  */
 export const formatBalance = (value: bigint): string => {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -260,7 +260,7 @@
     "to": "An:",
     "from": "Von:",
     "tick": "Tick",
-    "type": "Typ",
+    "txType": "TX-Typ",
     "pending": "Ausstehend",
     "unconfirmed": "Unbestätigt",
     "unconfirmedMore": "+{{count}} weitere unbestätigte",
@@ -282,7 +282,7 @@
     "txId": "TX-ID",
     "amount": "Betrag",
     "tick": "Tick",
-    "inputType": "Eingabetyp",
+    "txType": "TX Typ",
     "source": "Quelle",
     "destination": "Ziel",
     "timestamp": "Zeitstempel",
@@ -446,7 +446,7 @@
       "messageEmpty": "Keine Nachrichtenvorschau verfügbar.",
       "txTo": "An",
       "txAmount": "Betrag",
-      "txInputType": "Eingabetyp",
+      "txType": "TX Typ",
       "txTargetTick": "Ziel-Tick",
       "txTargetTickOffset": "Ziel-Tick-Offset",
       "txInputBytes": "Eingabedaten",
@@ -463,7 +463,8 @@
     }
   },
   "transaction": {
-    "broadcastDescription": "Deine Transaktion wurde übertragen und ist für Tick {{targetTick}} eingeplant."
+    "broadcastDescription": "Deine Transaktion wurde übertragen und ist für Tick {{targetTick}} eingeplant.",
+    "txTypeTransfer": "Überweisung"
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -345,8 +345,7 @@
       "cancel": "Abbrechen"
     },
     "success": {
-      "title": "Überweisung gesendet",
-      "description": "Deine Transaktion wurde übertragen und ist für Tick {{targetTick}} eingeplant."
+      "title": "Überweisung gesendet"
     },
     "errors": {
       "networkError": "Netzwerkfehler. Bitte erneut versuchen.",
@@ -394,8 +393,7 @@
       "cancel": "Abbrechen"
     },
     "success": {
-      "title": "Rechte übertragen",
-      "description": "Deine Transaktion wurde übertragen und ist für Tick {{targetTick}} eingeplant."
+      "title": "Rechte übertragen"
     },
     "errors": {
       "networkError": "Netzwerkfehler. Bitte erneut versuchen.",
@@ -454,6 +452,7 @@
       "txInputBytes": "Eingabedaten",
       "txInputBytesExpand": "Mehr anzeigen",
       "txInputBytesCollapse": "Weniger anzeigen",
+      "txBroadcastSuccess": "Transaktion gesendet",
       "approve": "Genehmigen",
       "approveAndSend": "Genehmigen & senden",
       "reject": "Ablehnen",
@@ -462,6 +461,9 @@
         "decisionFailed": "Entscheidung konnte nicht übermittelt werden."
       }
     }
+  },
+  "transaction": {
+    "broadcastDescription": "Deine Transaktion wurde übertragen und ist für Tick {{targetTick}} eingeplant."
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -260,7 +260,7 @@
     "to": "To:",
     "from": "From:",
     "tick": "Tick",
-    "type": "Type",
+    "txType": "TX Type",
     "pending": "Pending",
     "unconfirmed": "Unconfirmed",
     "unconfirmedMore": "+{{count}} more unconfirmed",
@@ -282,7 +282,7 @@
     "txId": "TX ID",
     "amount": "Amount",
     "tick": "Tick",
-    "inputType": "Input type",
+    "txType": "TX Type",
     "source": "Source",
     "destination": "Destination",
     "timestamp": "Timestamp",
@@ -446,7 +446,7 @@
       "messageEmpty": "No message preview available.",
       "txTo": "To",
       "txAmount": "Amount",
-      "txInputType": "Input type",
+      "txType": "TX Type",
       "txTargetTick": "Target tick",
       "txTargetTickOffset": "Target tick offset",
       "txInputBytes": "Input data",
@@ -463,7 +463,8 @@
     }
   },
   "transaction": {
-    "broadcastDescription": "Your transaction has been broadcast and is scheduled for tick {{targetTick}}."
+    "broadcastDescription": "Your transaction has been broadcast and is scheduled for tick {{targetTick}}.",
+    "txTypeTransfer": "Transfer"
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -345,8 +345,7 @@
       "cancel": "Cancel"
     },
     "success": {
-      "title": "Transfer sent",
-      "description": "Your transaction has been broadcast and is scheduled for tick {{targetTick}}."
+      "title": "Transfer sent"
     },
     "errors": {
       "networkError": "Network error. Please retry.",
@@ -394,8 +393,7 @@
       "cancel": "Cancel"
     },
     "success": {
-      "title": "Transfer rights sent",
-      "description": "Your transaction has been broadcast and is scheduled for tick {{targetTick}}."
+      "title": "Transfer rights sent"
     },
     "errors": {
       "networkError": "Network error. Please retry.",
@@ -454,6 +452,7 @@
       "txInputBytes": "Input data",
       "txInputBytesExpand": "Show more",
       "txInputBytesCollapse": "Show less",
+      "txBroadcastSuccess": "Transaction submitted",
       "approve": "Approve",
       "approveAndSend": "Approve & Send",
       "reject": "Reject",
@@ -462,6 +461,9 @@
         "decisionFailed": "Could not submit your decision."
       }
     }
+  },
+  "transaction": {
+    "broadcastDescription": "Your transaction has been broadcast and is scheduled for tick {{targetTick}}."
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -260,7 +260,7 @@
     "to": "A:",
     "from": "De:",
     "tick": "Tick",
-    "type": "Tipo",
+    "txType": "Tipo de TX",
     "pending": "Pendiente",
     "unconfirmed": "Sin confirmar",
     "unconfirmedMore": "+{{count}} más sin confirmar",
@@ -282,7 +282,7 @@
     "txId": "ID de TX",
     "amount": "Monto",
     "tick": "Tick",
-    "inputType": "Tipo de input",
+    "txType": "TX Tipo",
     "source": "Origen",
     "destination": "Destino",
     "timestamp": "Fecha",
@@ -446,7 +446,7 @@
       "messageEmpty": "No hay vista previa del mensaje.",
       "txTo": "Para",
       "txAmount": "Cantidad",
-      "txInputType": "Tipo de entrada",
+      "txType": "TX Tipo",
       "txTargetTick": "Tick objetivo",
       "txTargetTickOffset": "Offset del tick objetivo",
       "txInputBytes": "Datos de entrada",
@@ -463,7 +463,8 @@
     }
   },
   "transaction": {
-    "broadcastDescription": "Tu transacción ha sido transmitida y está programada para el tick {{targetTick}}."
+    "broadcastDescription": "Tu transacción ha sido transmitida y está programada para el tick {{targetTick}}.",
+    "txTypeTransfer": "Transferencia"
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -345,8 +345,7 @@
       "cancel": "Cancelar"
     },
     "success": {
-      "title": "Transferencia enviada",
-      "description": "Tu transacción ha sido transmitida y está programada para el tick {{targetTick}}."
+      "title": "Transferencia enviada"
     },
     "errors": {
       "networkError": "Error de red. Intenta de nuevo.",
@@ -394,8 +393,7 @@
       "cancel": "Cancelar"
     },
     "success": {
-      "title": "Derechos transferidos",
-      "description": "Tu transacción ha sido transmitida y está programada para el tick {{targetTick}}."
+      "title": "Derechos transferidos"
     },
     "errors": {
       "networkError": "Error de red. Intenta de nuevo.",
@@ -454,6 +452,7 @@
       "txInputBytes": "Datos de entrada",
       "txInputBytesExpand": "Ver más",
       "txInputBytesCollapse": "Ver menos",
+      "txBroadcastSuccess": "Transacción enviada",
       "approve": "Aprobar",
       "approveAndSend": "Aprobar y enviar",
       "reject": "Rechazar",
@@ -462,6 +461,9 @@
         "decisionFailed": "No se pudo enviar tu decisión."
       }
     }
+  },
+  "transaction": {
+    "broadcastDescription": "Tu transacción ha sido transmitida y está programada para el tick {{targetTick}}."
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -345,8 +345,7 @@
       "cancel": "Annuler"
     },
     "success": {
-      "title": "Transfert envoyé",
-      "description": "Votre transaction a été diffusée et est programmée pour le tick {{targetTick}}."
+      "title": "Transfert envoyé"
     },
     "errors": {
       "networkError": "Erreur réseau. Veuillez réessayer.",
@@ -394,8 +393,7 @@
       "cancel": "Annuler"
     },
     "success": {
-      "title": "Transfert de droits envoyé",
-      "description": "Votre transaction a été diffusée et est programmée pour le tick {{targetTick}}."
+      "title": "Transfert de droits envoyé"
     },
     "errors": {
       "networkError": "Erreur réseau. Veuillez réessayer.",
@@ -454,6 +452,7 @@
       "txInputBytes": "Données d'entrée",
       "txInputBytesExpand": "Voir plus",
       "txInputBytesCollapse": "Voir moins",
+      "txBroadcastSuccess": "Transaction soumise",
       "approve": "Approuver",
       "approveAndSend": "Approuver et envoyer",
       "reject": "Rejeter",
@@ -462,6 +461,9 @@
         "decisionFailed": "Impossible de soumettre votre décision."
       }
     }
+  },
+  "transaction": {
+    "broadcastDescription": "Votre transaction a été diffusée et est programmée pour le tick {{targetTick}}."
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -260,7 +260,7 @@
     "to": "À :",
     "from": "De :",
     "tick": "Tick",
-    "type": "Type",
+    "txType": "Type de TX",
     "pending": "En attente",
     "unconfirmed": "Non confirmé",
     "unconfirmedMore": "+{{count}} non confirmées supplémentaires",
@@ -282,7 +282,7 @@
     "txId": "ID de TX",
     "amount": "Montant",
     "tick": "Tick",
-    "inputType": "Type d'entrée",
+    "txType": "TX Type",
     "source": "Source",
     "destination": "Destination",
     "timestamp": "Horodatage",
@@ -446,7 +446,7 @@
       "messageEmpty": "Aucun aperçu du message disponible.",
       "txTo": "À",
       "txAmount": "Montant",
-      "txInputType": "Type d'entrée",
+      "txType": "TX Type",
       "txTargetTick": "Tick cible",
       "txTargetTickOffset": "Décalage du tick cible",
       "txInputBytes": "Données d'entrée",
@@ -463,7 +463,8 @@
     }
   },
   "transaction": {
-    "broadcastDescription": "Votre transaction a été diffusée et est programmée pour le tick {{targetTick}}."
+    "broadcastDescription": "Votre transaction a été diffusée et est programmée pour le tick {{targetTick}}.",
+    "txTypeTransfer": "Transfert"
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -260,7 +260,7 @@
     "to": "Кому:",
     "from": "От:",
     "tick": "Tick",
-    "type": "Тип",
+    "txType": "Тип TX",
     "pending": "В ожидании",
     "unconfirmed": "Не подтверждено",
     "unconfirmedMore": "+{{count}} еще не подтверждено",
@@ -282,7 +282,7 @@
     "txId": "ID транзакции",
     "amount": "Сумма",
     "tick": "Tick",
-    "inputType": "Тип ввода",
+    "txType": "TX Тип",
     "source": "Отправитель",
     "destination": "Получатель",
     "timestamp": "Дата",
@@ -446,7 +446,7 @@
       "messageEmpty": "Предварительный просмотр сообщения недоступен.",
       "txTo": "Кому",
       "txAmount": "Сумма",
-      "txInputType": "Тип ввода",
+      "txType": "TX Тип",
       "txTargetTick": "Целевой тик",
       "txTargetTickOffset": "Смещение целевого тика",
       "txInputBytes": "Входные данные",
@@ -463,7 +463,8 @@
     }
   },
   "transaction": {
-    "broadcastDescription": "Ваша транзакция отправлена в сеть и запланирована на тик {{targetTick}}."
+    "broadcastDescription": "Ваша транзакция отправлена в сеть и запланирована на тик {{targetTick}}.",
+    "txTypeTransfer": "Перевод"
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -345,8 +345,7 @@
       "cancel": "Отмена"
     },
     "success": {
-      "title": "Перевод отправлен",
-      "description": "Ваша транзакция отправлена в сеть и запланирована на тик {{targetTick}}."
+      "title": "Перевод отправлен"
     },
     "errors": {
       "networkError": "Ошибка сети. Попробуйте снова.",
@@ -394,8 +393,7 @@
       "cancel": "Отмена"
     },
     "success": {
-      "title": "Права переданы",
-      "description": "Ваша транзакция отправлена в сеть и запланирована на тик {{targetTick}}."
+      "title": "Права переданы"
     },
     "errors": {
       "networkError": "Ошибка сети. Попробуйте снова.",
@@ -454,6 +452,7 @@
       "txInputBytes": "Входные данные",
       "txInputBytesExpand": "Показать больше",
       "txInputBytesCollapse": "Показать меньше",
+      "txBroadcastSuccess": "Транзакция отправлена",
       "approve": "Одобрить",
       "approveAndSend": "Одобрить и отправить",
       "reject": "Отклонить",
@@ -462,6 +461,9 @@
         "decisionFailed": "Не удалось отправить ваше решение."
       }
     }
+  },
+  "transaction": {
+    "broadcastDescription": "Ваша транзакция отправлена в сеть и запланирована на тик {{targetTick}}."
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -345,8 +345,7 @@
       "cancel": "İptal"
     },
     "success": {
-      "title": "Transfer gönderildi",
-      "description": "İşleminiz yayınlandı ve tick {{targetTick}} için planlandı."
+      "title": "Transfer gönderildi"
     },
     "errors": {
       "networkError": "Ağ hatası. Lütfen tekrar deneyin.",
@@ -394,8 +393,7 @@
       "cancel": "İptal"
     },
     "success": {
-      "title": "Hak transferi gönderildi",
-      "description": "İşleminiz yayınlandı ve tick {{targetTick}} için planlandı."
+      "title": "Hak transferi gönderildi"
     },
     "errors": {
       "networkError": "Ağ hatası. Lütfen tekrar deneyin.",
@@ -454,6 +452,7 @@
       "txInputBytes": "Giriş verisi",
       "txInputBytesExpand": "Daha fazla göster",
       "txInputBytesCollapse": "Daha az göster",
+      "txBroadcastSuccess": "İşlem gönderildi",
       "approve": "Onayla",
       "approveAndSend": "Onayla ve Gönder",
       "reject": "Reddet",
@@ -462,6 +461,9 @@
         "decisionFailed": "Kararınız gönderilemedi."
       }
     }
+  },
+  "transaction": {
+    "broadcastDescription": "İşleminiz yayınlandı ve tick {{targetTick}} için planlandı."
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -260,7 +260,7 @@
     "to": "Alıcı:",
     "from": "Gönderen:",
     "tick": "Tick",
-    "type": "Tür",
+    "txType": "TX Türü",
     "pending": "Onay Bekliyor",
     "unconfirmed": "Onaylanmamış",
     "unconfirmedMore": "+{{count}} onaylanmamış işlem daha",
@@ -282,7 +282,7 @@
     "txId": "TX ID",
     "amount": "Miktar",
     "tick": "Tick",
-    "inputType": "Giriş türü",
+    "txType": "TX Türü",
     "source": "Kaynak",
     "destination": "Hedef",
     "timestamp": "Zaman damgası",
@@ -446,7 +446,7 @@
       "messageEmpty": "Mesaj önizlemesi mevcut değil.",
       "txTo": "Alıcı",
       "txAmount": "Miktar",
-      "txInputType": "Giriş türü",
+      "txType": "TX Türü",
       "txTargetTick": "Hedef tick",
       "txTargetTickOffset": "Hedef tick ofseti",
       "txInputBytes": "Giriş verisi",
@@ -463,7 +463,8 @@
     }
   },
   "transaction": {
-    "broadcastDescription": "İşleminiz yayınlandı ve tick {{targetTick}} için planlandı."
+    "broadcastDescription": "İşleminiz yayınlandı ve tick {{targetTick}} için planlandı.",
+    "txTypeTransfer": "Transfer"
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -345,8 +345,7 @@
       "cancel": "Hủy"
     },
     "success": {
-      "title": "Chuyển khoản đã gửi",
-      "description": "Giao dịch của bạn đã được truyền và được lên lịch cho tick {{targetTick}}."
+      "title": "Chuyển khoản đã gửi"
     },
     "errors": {
       "networkError": "Lỗi mạng. Vui lòng thử lại.",
@@ -394,8 +393,7 @@
       "cancel": "Hủy"
     },
     "success": {
-      "title": "Quyền đã được chuyển",
-      "description": "Giao dịch của bạn đã được truyền và được lên lịch cho tick {{targetTick}}."
+      "title": "Quyền đã được chuyển"
     },
     "errors": {
       "networkError": "Lỗi mạng. Vui lòng thử lại.",
@@ -454,6 +452,7 @@
       "txInputBytes": "Dữ liệu đầu vào",
       "txInputBytesExpand": "Xem thêm",
       "txInputBytesCollapse": "Thu gọn",
+      "txBroadcastSuccess": "Giao dịch đã gửi",
       "approve": "Chấp thuận",
       "approveAndSend": "Chấp thuận và gửi",
       "reject": "Từ chối",
@@ -462,6 +461,9 @@
         "decisionFailed": "Không thể gửi quyết định của bạn."
       }
     }
+  },
+  "transaction": {
+    "broadcastDescription": "Giao dịch của bạn đã được truyền và được lên lịch cho tick {{targetTick}}."
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -260,7 +260,7 @@
     "to": "Đến:",
     "from": "Từ:",
     "tick": "Tick",
-    "type": "Loại",
+    "txType": "Loại TX",
     "pending": "Đang chờ",
     "unconfirmed": "Chưa xác nhận",
     "unconfirmedMore": "+{{count}} chưa xác nhận khác",
@@ -282,7 +282,7 @@
     "txId": "ID giao dịch",
     "amount": "Số lượng",
     "tick": "Tick",
-    "inputType": "Loại đầu vào",
+    "txType": "TX Loại",
     "source": "Nguồn",
     "destination": "Đích",
     "timestamp": "Thời gian",
@@ -446,7 +446,7 @@
       "messageEmpty": "Không có bản xem trước tin nhắn.",
       "txTo": "Đến",
       "txAmount": "Số lượng",
-      "txInputType": "Loại đầu vào",
+      "txType": "TX Loại",
       "txTargetTick": "Tick mục tiêu",
       "txTargetTickOffset": "Độ lệch tick mục tiêu",
       "txInputBytes": "Dữ liệu đầu vào",
@@ -463,7 +463,8 @@
     }
   },
   "transaction": {
-    "broadcastDescription": "Giao dịch của bạn đã được truyền và được lên lịch cho tick {{targetTick}}."
+    "broadcastDescription": "Giao dịch của bạn đã được truyền và được lên lịch cho tick {{targetTick}}.",
+    "txTypeTransfer": "Chuyển khoản"
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -260,7 +260,7 @@
     "to": "收款方：",
     "from": "发送方：",
     "tick": "Tick",
-    "type": "类型",
+    "txType": "交易类型",
     "pending": "待确认",
     "unconfirmed": "未确认",
     "unconfirmedMore": "+{{count}} 笔未确认",
@@ -282,7 +282,7 @@
     "txId": "交易 ID",
     "amount": "金额",
     "tick": "Tick",
-    "inputType": "输入类型",
+    "txType": "TX 类型",
     "source": "发送方",
     "destination": "接收方",
     "timestamp": "时间戳",
@@ -446,7 +446,7 @@
       "messageEmpty": "无消息预览。",
       "txTo": "收款方",
       "txAmount": "金额",
-      "txInputType": "输入类型",
+      "txType": "TX 类型",
       "txTargetTick": "目标 Tick",
       "txTargetTickOffset": "目标 Tick 偏移量",
       "txInputBytes": "输入数据",
@@ -463,7 +463,8 @@
     }
   },
   "transaction": {
-    "broadcastDescription": "您的交易已广播，计划在 Tick {{targetTick}} 执行。"
+    "broadcastDescription": "您的交易已广播，计划在 Tick {{targetTick}} 执行。",
+    "txTypeTransfer": "转账"
   },
   "onboarding": {
     "importSeed": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -345,8 +345,7 @@
       "cancel": "取消"
     },
     "success": {
-      "title": "转账已发送",
-      "description": "您的交易已广播，计划在 Tick {{targetTick}} 执行。"
+      "title": "转账已发送"
     },
     "errors": {
       "networkError": "网络错误，请重试。",
@@ -394,8 +393,7 @@
       "cancel": "取消"
     },
     "success": {
-      "title": "权限转移已发送",
-      "description": "您的交易已广播，计划在 Tick {{targetTick}} 执行。"
+      "title": "权限转移已发送"
     },
     "errors": {
       "networkError": "网络错误，请重试。",
@@ -454,6 +452,7 @@
       "txInputBytes": "输入数据",
       "txInputBytesExpand": "展开",
       "txInputBytesCollapse": "收起",
+      "txBroadcastSuccess": "交易已提交",
       "approve": "批准",
       "approveAndSend": "批准并发送",
       "reject": "拒绝",
@@ -462,6 +461,9 @@
         "decisionFailed": "无法提交您的决定。"
       }
     }
+  },
+  "transaction": {
+    "broadcastDescription": "您的交易已广播，计划在 Tick {{targetTick}} 执行。"
   },
   "onboarding": {
     "importSeed": {

--- a/src/pages/history.tsx
+++ b/src/pages/history.tsx
@@ -2,7 +2,7 @@ import { useTransactions } from '@qubic-labs/react'
 import { HashIcon, RefreshCwIcon, XIcon } from 'lucide-react'
 import { getTransactionPresentation } from '@/lib/transaction-presentation'
 import { Button } from '@/components/ui/button'
-import { useProcedureName } from '@/hooks/use-procedure-name'
+import { useTxTypeDescription } from '@/hooks/use-tx-type-description'
 import AddressLabel from '@/components/address-label'
 import {
   buildExplorerObjectUrl,
@@ -59,16 +59,9 @@ type HistoryRowTransaction = {
 
 type HistoryRowState = 'default' | 'pending' | 'failed'
 
-const InputTypeLabel = ({ destination, inputType }: { destination: string; inputType: number }) => {
-  const procedureName = useProcedureName(destination, inputType)
-  if (procedureName) {
-    return (
-      <span>
-        {inputType} ({procedureName})
-      </span>
-    )
-  }
-  return <span>{inputType.toString()}</span>
+const TxTypeLabel = ({ destination, inputType }: { destination: string; inputType: number }) => {
+  const description = useTxTypeDescription(destination, inputType)
+  return <span>{description}</span>
 }
 
 const History = () => {
@@ -293,8 +286,8 @@ const History = () => {
           </div>
           {Number(tx.inputType) !== 0 && (
             <div className="flex items-center gap-1 font-mono">
-              <span className="text-muted-foreground/70">{t('history.type')}</span>
-              <InputTypeLabel destination={tx.destination} inputType={Number(tx.inputType)} />
+              <span className="text-muted-foreground/70">{t('history.txType')}</span>
+              <TxTypeLabel destination={tx.destination} inputType={Number(tx.inputType)} />
             </div>
           )}
         </div>
@@ -494,8 +487,10 @@ const History = () => {
                           </div>
                           {Number(tx.inputType) !== 0 && (
                             <div className="flex items-center gap-1 font-mono">
-                              <span className="text-muted-foreground/70">{t('history.type')}</span>
-                              <InputTypeLabel
+                              <span className="text-muted-foreground/70">
+                                {t('history.txType')}
+                              </span>
+                              <TxTypeLabel
                                 destination={tx.destination}
                                 inputType={Number(tx.inputType)}
                               />

--- a/src/pages/transaction-details.tsx
+++ b/src/pages/transaction-details.tsx
@@ -88,20 +88,6 @@ const TransactionDetails = () => {
           : '--',
     },
     {
-      key: 'timestamp',
-      label: t('txDetails.timestamp'),
-      value: formatTimestamp(details?.timestamp),
-    },
-    {
-      key: 'tick',
-      label: t('txDetails.tick'),
-      value: (() => {
-        const tick = details?.tickNumber ?? details?.tick ?? pending?.targetTick
-        if (tick === null || tick === undefined) return '--'
-        return formatNumber(Number(tick))
-      })(),
-    },
-    {
       key: 'inputType',
       label: t('txDetails.txType'),
       value: txTypeDescription,
@@ -119,6 +105,20 @@ const TransactionDetails = () => {
       value: destName ? formatAddressLabel(destAddress, destName.name) : details?.destination,
       copyable: true,
       copyText: destAddress,
+    },
+    {
+      key: 'tick',
+      label: t('txDetails.tick'),
+      value: (() => {
+        const tick = details?.tickNumber ?? details?.tick ?? pending?.targetTick
+        if (tick === null || tick === undefined) return '--'
+        return formatNumber(Number(tick))
+      })(),
+    },
+    {
+      key: 'timestamp',
+      label: t('txDetails.timestamp'),
+      value: formatTimestamp(details?.timestamp),
     },
   ]
 

--- a/src/pages/transaction-details.tsx
+++ b/src/pages/transaction-details.tsx
@@ -10,29 +10,11 @@ import {
   usePendingTransactionsVersion,
 } from '@/lib/pending-transactions'
 import { useAddressName } from '@/hooks/use-address-name'
-import { useProcedureName } from '@/hooks/use-procedure-name'
+import { useTxTypeDescription } from '@/hooks/use-tx-type-description'
 import { useClipboardCopy } from '@/hooks/use-clipboard-copy'
-import { formatAddressLabel, formatNumber } from '@/lib/utils'
+import { formatAddressLabel, formatIntegerLike, formatNumber } from '@/lib/utils'
 import TxDetailsHeader from '@/components/pages/transaction-details/tx-details-header'
 import TxDetailsRow, { formatValue } from '@/components/pages/transaction-details/tx-details-row'
-
-const formatIntegerLike = (value: unknown): string => {
-  if (value === null || value === undefined) return '--'
-
-  if (typeof value === 'bigint') return formatNumber(value)
-
-  if (typeof value === 'number') {
-    if (!Number.isFinite(value)) return '--'
-    return formatNumber(Math.trunc(value))
-  }
-
-  if (typeof value === 'string') {
-    const normalized = value.trim()
-    if (/^-?\d+$/.test(normalized)) return formatNumber(BigInt(normalized))
-  }
-
-  return formatValue(value)
-}
 
 const TX_DETAILS_SKELETON_IDS = ['a', 'b', 'c', 'd', 'e', 'f'] as const
 
@@ -71,7 +53,7 @@ const TransactionDetails = () => {
   const destAddress = (details?.destination as string) ?? ''
   const sourceName = useAddressName(sourceAddress)
   const destName = useAddressName(destAddress)
-  const procedureName = useProcedureName(destAddress, Number(details?.inputType ?? 0))
+  const txTypeDescription = useTxTypeDescription(destAddress, Number(details?.inputType ?? 0))
 
   const formatTimestamp = (ts: unknown): string => {
     if (ts === null || ts === undefined) return '--'
@@ -117,8 +99,8 @@ const TransactionDetails = () => {
     },
     {
       key: 'inputType',
-      label: t('txDetails.inputType'),
-      value: procedureName ? `${details?.inputType} (${procedureName})` : details?.inputType,
+      label: t('txDetails.txType'),
+      value: txTypeDescription,
     },
     {
       key: 'source',

--- a/src/pages/transaction-details.tsx
+++ b/src/pages/transaction-details.tsx
@@ -13,6 +13,7 @@ import { useAddressName } from '@/hooks/use-address-name'
 import { useTxTypeDescription } from '@/hooks/use-tx-type-description'
 import { useClipboardCopy } from '@/hooks/use-clipboard-copy'
 import { formatAddressLabel, formatIntegerLike, formatNumber } from '@/lib/utils'
+import { NATIVE_TOKEN_SYMBOL } from '@/lib/config/constants'
 import TxDetailsHeader from '@/components/pages/transaction-details/tx-details-header'
 import TxDetailsRow, { formatValue } from '@/components/pages/transaction-details/tx-details-row'
 
@@ -81,7 +82,10 @@ const TransactionDetails = () => {
     {
       key: 'amount',
       label: t('txDetails.amount'),
-      value: formatIntegerLike(details?.amount),
+      value:
+        details?.amount != null
+          ? `${formatIntegerLike(details.amount)} ${NATIVE_TOKEN_SYMBOL}`
+          : '--',
     },
     {
       key: 'timestamp',

--- a/src/pages/transfer-rights.tsx
+++ b/src/pages/transfer-rights.tsx
@@ -374,7 +374,7 @@ const TransferRights = () => {
       setDrawerOpen(false)
 
       toast.success(t('transferRights.success.title'), {
-        description: t('transferRights.success.description', {
+        description: t('transaction.broadcastDescription', {
           targetTick: formatNumber(Number(result.targetTick)),
         }),
       })

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -286,7 +286,7 @@ const Transfer = () => {
       setDrawerOpen(false)
 
       toast.success(t('transfer.success.title'), {
-        description: t('transfer.success.description', {
+        description: t('transaction.broadcastDescription', {
           targetTick: formatNumber(Number(result.targetTick)),
         }),
       })


### PR DESCRIPTION
- Show toast notification after dApp sendTransaction broadcast (success/error)
- Extract shared `formatIntegerLike` utility and `useTxTypeDescription` hook
- Unify TX type display format (`Name (id)` / `Transfer (0)`) across approval drawer, tx details, and history
- Rename "Input type" to "TX Type" across all 8 locales
- Show QU symbol next to amounts in tx details and approval drawer
- Align tx details field order with explorer-frontend
- Use green color for incoming amounts, muted for zero
- Fix failed tx layout alignment on home screen
- Only show target tick in approval when explicitly assigned