### PR TITLE
feat(dapp): per-method approval titles and dApp favicon

### DIFF
--- a/src/components/dapp/dapp-approval-drawer.tsx
+++ b/src/components/dapp/dapp-approval-drawer.tsx
@@ -38,6 +38,7 @@ const DappApprovalDrawer = () => {
   const [error, setError] = useState('')
   const [passphrase, setPassphrase] = useState('')
   const [inputBytesExpanded, setInputBytesExpanded] = useState(false)
+  const [faviconError, setFaviconError] = useState<string | null>(null)
   const [locked, setLocked] = useState(() => isWalletLocked())
   const isDappApprovalPopup =
     window.location.pathname.endsWith('popup.html') &&
@@ -94,6 +95,22 @@ const DappApprovalDrawer = () => {
     Number(txSummary?.inputType ?? 0),
   )
 
+  const title = useMemo(() => {
+    if (!current) return ''
+    switch (current.method) {
+      case 'connect':
+        return t('dapp.approval.connectTitle')
+      case 'signMessage':
+        return t('dapp.approval.signMessageTitle')
+      case 'signTransaction':
+        return t('dapp.approval.signTransactionTitle')
+      case 'sendTransaction':
+        return t('dapp.approval.sendTransactionTitle')
+      default:
+        return t('dapp.approval.title')
+    }
+  }, [current, t])
+
   const subtitle = useMemo(() => {
     if (!current) return ''
     switch (current.method) {
@@ -109,6 +126,16 @@ const DappApprovalDrawer = () => {
         return t('dapp.approval.genericSubtitle')
     }
   }, [current, t])
+
+  const faviconUrl = useMemo(() => {
+    if (!current?.origin) return null
+    try {
+      const url = new URL(current.origin)
+      return `${url.origin}/favicon.ico`
+    } catch {
+      return null
+    }
+  }, [current?.origin])
 
   const submitDecision = async (approved: boolean) => {
     if (!current) return
@@ -188,9 +215,18 @@ const DappApprovalDrawer = () => {
       >
         <DrawerHeader className="space-y-2 text-center">
           <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
-            <GlobeIcon className="h-6 w-6 shrink-0 text-primary" />
+            {faviconUrl && faviconError !== faviconUrl ? (
+              <img
+                src={faviconUrl}
+                alt=""
+                className="h-6 w-6 shrink-0 rounded-sm"
+                onError={() => setFaviconError(faviconUrl)}
+              />
+            ) : (
+              <GlobeIcon className="h-6 w-6 shrink-0 text-primary" />
+            )}
           </div>
-          <DrawerTitle>{t('dapp.approval.title')}</DrawerTitle>
+          <DrawerTitle>{title}</DrawerTitle>
           <DrawerDescription>{subtitle}</DrawerDescription>
         </DrawerHeader>
 

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -436,6 +436,10 @@
   "dapp": {
     "approval": {
       "title": "Verbindungsanfrage",
+      "connectTitle": "Verbindungsanfrage",
+      "signMessageTitle": "Nachricht signieren",
+      "signTransactionTitle": "Transaktion signieren",
+      "sendTransactionTitle": "Transaktion senden",
       "origin": "Website",
       "sharedAccount": "Geteiltes Konto",
       "sharedAccountFallback": "Ausgewähltes Konto",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -436,6 +436,10 @@
   "dapp": {
     "approval": {
       "title": "Connection request",
+      "connectTitle": "Connection request",
+      "signMessageTitle": "Sign message",
+      "signTransactionTitle": "Sign transaction",
+      "sendTransactionTitle": "Send transaction",
       "origin": "Website",
       "sharedAccount": "Shared account",
       "sharedAccountFallback": "Selected account",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -436,6 +436,10 @@
   "dapp": {
     "approval": {
       "title": "Solicitud de conexión",
+      "connectTitle": "Solicitud de conexión",
+      "signMessageTitle": "Firmar mensaje",
+      "signTransactionTitle": "Firmar transacción",
+      "sendTransactionTitle": "Enviar transacción",
       "origin": "Sitio web",
       "sharedAccount": "Cuenta compartida",
       "sharedAccountFallback": "Cuenta seleccionada",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -436,6 +436,10 @@
   "dapp": {
     "approval": {
       "title": "Demande de connexion",
+      "connectTitle": "Demande de connexion",
+      "signMessageTitle": "Signer un message",
+      "signTransactionTitle": "Signer une transaction",
+      "sendTransactionTitle": "Envoyer une transaction",
       "origin": "Site web",
       "sharedAccount": "Compte partagé",
       "sharedAccountFallback": "Compte sélectionné",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -436,6 +436,10 @@
   "dapp": {
     "approval": {
       "title": "Запрос на подключение",
+      "connectTitle": "Запрос на подключение",
+      "signMessageTitle": "Подписать сообщение",
+      "signTransactionTitle": "Подписать транзакцию",
+      "sendTransactionTitle": "Отправить транзакцию",
       "origin": "Веб-сайт",
       "sharedAccount": "Общий аккаунт",
       "sharedAccountFallback": "Выбранный аккаунт",

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -436,6 +436,10 @@
   "dapp": {
     "approval": {
       "title": "Bağlantı isteği",
+      "connectTitle": "Bağlantı isteği",
+      "signMessageTitle": "Mesaj imzala",
+      "signTransactionTitle": "İşlem imzala",
+      "sendTransactionTitle": "İşlem gönder",
       "origin": "Web sitesi",
       "sharedAccount": "Paylaşılan hesap",
       "sharedAccountFallback": "Seçili hesap",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -436,6 +436,10 @@
   "dapp": {
     "approval": {
       "title": "Yêu cầu kết nối",
+      "connectTitle": "Yêu cầu kết nối",
+      "signMessageTitle": "Ký tin nhắn",
+      "signTransactionTitle": "Ký giao dịch",
+      "sendTransactionTitle": "Gửi giao dịch",
       "origin": "Trang web",
       "sharedAccount": "Tài khoản chia sẻ",
       "sharedAccountFallback": "Tài khoản đã chọn",

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -436,6 +436,10 @@
   "dapp": {
     "approval": {
       "title": "连接请求",
+      "connectTitle": "连接请求",
+      "signMessageTitle": "签署消息",
+      "signTransactionTitle": "签署交易",
+      "sendTransactionTitle": "发送交易",
       "origin": "网站",
       "sharedAccount": "共享账户",
       "sharedAccountFallback": "已选账户",


### PR DESCRIPTION
## Summary
- Show method-specific titles in approval drawer (Connection request, Sign message, Sign transaction, Send transaction)
- Display dApp favicon from origin with GlobeIcon fallback on error
- Add i18n keys for all 8 locales