### PR TITLE
fix(dapp): strict numeric validation and tick-in-past rejection

### DIFF
--- a/src/lib/dapp/controller.ts
+++ b/src/lib/dapp/controller.ts
@@ -41,7 +41,7 @@ import {
   DAPP_SEND_TRANSACTION_TARGET_TICK_OFFSET_MAX,
   DAPP_SEND_TRANSACTION_TARGET_TICK_OFFSET_MIN,
 } from '@/lib/dapp/timing'
-import { validateDappMethodParams } from '@/lib/dapp/validators'
+import { parseOptionalInteger, validateDappMethodParams } from '@/lib/dapp/validators'
 import {
   sendTransactionFromSeed,
   parseSignTransactionParams,
@@ -234,6 +234,7 @@ const queueSigningApproval = async (
         'Destination identity cannot match source identity',
       )
     }
+    await rejectIfTickInPast(parsedParams.targetTick)
   }
   await enqueueApprovalRequest({
     id: request.id,
@@ -248,24 +249,23 @@ const queueSigningApproval = async (
   return asRuntimePendingAck(request.id)
 }
 
-const toOptionalInteger = (value: unknown): number | undefined => {
-  if (value === undefined || value === null) return undefined
-  const numeric =
-    typeof value === 'number'
-      ? value
-      : typeof value === 'bigint'
-        ? Number(value)
-        : typeof value === 'string'
-          ? Number.parseInt(value.trim(), 10)
-          : Number.NaN
-  if (!Number.isFinite(numeric)) return undefined
-  return Math.trunc(numeric)
+const rejectIfTickInPast = async (targetTick: number | undefined): Promise<void> => {
+  if (targetTick === undefined) return
+  try {
+    const currentTick = Number((await sdk.rpc.live.tickInfo()).tick)
+    if (Number.isFinite(currentTick) && targetTick <= currentTick) {
+      throw new DappProviderError('INVALID_PARAMS', 'targetTick is already in the past')
+    }
+  } catch (error) {
+    if (error instanceof DappProviderError) throw error
+    // If we can't fetch the current tick, skip the check rather than blocking the request
+  }
 }
 
 const normalizeQueuedSendTransactionParams = (params: unknown) => {
   const input = (params && typeof params === 'object' ? params : {}) as DappSendTransactionParams
-  const explicitTargetTick = toOptionalInteger(input.targetTick)
-  const rawOffset = toOptionalInteger(input.targetTickOffset)
+  const explicitTargetTick = parseOptionalInteger(input.targetTick, 'targetTick')
+  const rawOffset = parseOptionalInteger(input.targetTickOffset, 'targetTickOffset')
 
   if (explicitTargetTick !== undefined && explicitTargetTick < 1) {
     throw new DappProviderError('INVALID_PARAMS', 'Invalid targetTick')
@@ -299,13 +299,14 @@ const normalizeQueuedSendTransactionParams = (params: unknown) => {
 const resolveSendTransactionParams = async (params: unknown) => {
   const normalized = normalizeQueuedSendTransactionParams(params)
   const input = normalized as Record<string, unknown>
-  const explicitTargetTick = toOptionalInteger(input.targetTick)
-  if (explicitTargetTick !== undefined) {
+  if (typeof input.targetTick === 'number') {
     return normalized
   }
 
   const offset =
-    toOptionalInteger(input.targetTickOffset) ?? DAPP_SEND_TRANSACTION_TARGET_TICK_OFFSET_DEFAULT
+    typeof input.targetTickOffset === 'number'
+      ? input.targetTickOffset
+      : DAPP_SEND_TRANSACTION_TARGET_TICK_OFFSET_DEFAULT
   let targetTick: number | undefined
 
   try {
@@ -360,6 +361,8 @@ const queueSendTransactionApproval = async (
       throw new DappProviderError('INVALID_PARAMS', 'Insufficient balance')
     }
   }
+  await rejectIfTickInPast(parsedParams.targetTick)
+
   const queuedParams = normalizeQueuedSendTransactionParams(request.params)
 
   await enqueueApprovalRequest({

--- a/src/lib/dapp/signing.ts
+++ b/src/lib/dapp/signing.ts
@@ -2,6 +2,7 @@ import { privateKeyFromSeed, publicKeyFromSeed } from '@qubic-labs/core'
 import { sign as signSchnorr, k12 } from '@qubic-labs/schnorrq'
 import type { BuiltTransaction, TransactionHelpers } from '@qubic-labs/sdk'
 import { DappProviderError } from '@/lib/dapp/errors'
+import { parseOptionalInteger } from '@/lib/dapp/validators'
 import { base64ToBytes, bytesToBase64, bytesToHex, hexToBytes } from '@/lib/encoding'
 import { isValidIdentity, parseAmount } from '@/lib/utils'
 
@@ -32,22 +33,6 @@ const toBigInt = (value: unknown, field: string): bigint => {
     if (/^\d+$/.test(trimmed)) return BigInt(trimmed)
   }
   throw new DappProviderError('INVALID_PARAMS', `Invalid ${field}`)
-}
-
-const toNumberOrUndefined = (value: unknown, field: string): number | undefined => {
-  if (value === undefined || value === null) return undefined
-  const numeric =
-    typeof value === 'number'
-      ? value
-      : typeof value === 'bigint'
-        ? Number(value)
-        : typeof value === 'string'
-          ? Number.parseInt(value, 10)
-          : Number.NaN
-  if (!Number.isFinite(numeric)) {
-    throw new DappProviderError('INVALID_PARAMS', `Invalid ${field}`)
-  }
-  return Math.trunc(numeric)
 }
 
 const decodeInputBytes = (value: unknown): Uint8Array | undefined => {
@@ -101,7 +86,7 @@ export const parseSignTransactionParams = (params: unknown): ParsedSignTransacti
     throw new DappProviderError('INVALID_PARAMS', 'Invalid toIdentity')
   }
 
-  const inputType = toNumberOrUndefined(input.inputType, 'inputType')
+  const inputType = parseOptionalInteger(input.inputType, 'inputType')
   const parsedAmount =
     typeof input.amount === 'string' ? parseAmount(input.amount) : toBigInt(input.amount, 'amount')
   if (parsedAmount === null || parsedAmount < 0n) {
@@ -114,7 +99,10 @@ export const parseSignTransactionParams = (params: unknown): ParsedSignTransacti
     )
   }
 
-  const targetTick = toNumberOrUndefined(input.targetTick, 'targetTick')
+  const targetTick = parseOptionalInteger(input.targetTick, 'targetTick')
+  if (targetTick !== undefined && targetTick < 1) {
+    throw new DappProviderError('INVALID_PARAMS', 'Invalid targetTick')
+  }
   const inputBytes = decodeInputBytes(input.inputBytes)
 
   return {

--- a/src/lib/dapp/validators.ts
+++ b/src/lib/dapp/validators.ts
@@ -1,8 +1,32 @@
 import { z } from 'zod'
 import type { DappMethod } from '@/lib/dapp/protocol'
+import { DappProviderError } from '@/lib/dapp/errors'
 
 const signTransactionSchema = z.record(z.string(), z.unknown())
 const signMessageSchema = z.union([z.string(), z.record(z.string(), z.unknown())])
+
+/**
+ * Parse an optional integer from unknown input.
+ * Returns `undefined` for null/undefined. Throws `INVALID_PARAMS` for present but invalid values.
+ */
+export const parseOptionalInteger = (value: unknown, field: string): number | undefined => {
+  if (value === undefined || value === null) return undefined
+  if (typeof value === 'string' && value.trim() === '') {
+    throw new DappProviderError('INVALID_PARAMS', `Invalid ${field}`)
+  }
+  const numeric =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'bigint'
+        ? Number(value)
+        : typeof value === 'string'
+          ? Number(value.trim())
+          : Number.NaN
+  if (!Number.isInteger(numeric)) {
+    throw new DappProviderError('INVALID_PARAMS', `Invalid ${field}`)
+  }
+  return numeric
+}
 
 export const validateDappMethodParams = (method: DappMethod, params: unknown) => {
   switch (method) {


### PR DESCRIPTION
Consolidate duplicate integer parsers into shared parseOptionalInteger that rejects invalid inputs instead of silently ignoring them. Add targetTick >= 1 validation for signTransaction and reject past ticks for both signTransaction and sendTransaction (fail-open if RPC is unreachable).