### PR TITLE
feat: add revoke asset management rights support and improve UI labels

### DIFF
--- a/src/components/pages/transfer/transfer-form.tsx
+++ b/src/components/pages/transfer/transfer-form.tsx
@@ -232,9 +232,12 @@ const TransferForm = ({
 
           {/* Asset transfer fee info */}
           {selectedAsset && (
-            <div className="rounded-lg border border-border/40 px-3 py-2 text-xs text-muted-foreground">
-              <div>{t('transfer.form.feeValue', { fee: '100' })}</div>
-              <div>{t('transfer.form.quBalance', { balance: formatBalance(quBalance) })}</div>
+            <div className="space-y-1.5">
+              <div className="rounded-lg border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+                <div>{t('transfer.form.feeValue', { fee: '100' })}</div>
+                <div>{t('transfer.form.quBalance', { balance: formatBalance(quBalance) })}</div>
+              </div>
+              {errors.fee && <p className="text-xs text-destructive">{errors.fee}</p>}
             </div>
           )}
 

--- a/src/components/pages/transfer/types.ts
+++ b/src/components/pages/transfer/types.ts
@@ -1,5 +1,6 @@
 export type FormErrors = {
   recipient?: string
   amount?: string
+  fee?: string
   targetTick?: string
 }

--- a/src/lib/qubic-static.types.ts
+++ b/src/lib/qubic-static.types.ts
@@ -1,6 +1,7 @@
 export type SmartContractProcedure = {
   id: number
   name: string
+  sourceIdentifier?: string
   fee?: number
 }
 

--- a/src/lib/transfer-rights.ts
+++ b/src/lib/transfer-rights.ts
@@ -1,44 +1,89 @@
 import { publicKeyFromIdentity } from '@qubic-labs/core'
 import type { SmartContract, SmartContractProcedure } from './qubic-static.types'
 
-const TRANSFER_SHARE_MANAGEMENT_RIGHTS_PROCEDURE = 'Transfer Share Management Rights'
+const TRANSFER_SHARE_MANAGEMENT_RIGHTS_IDENTIFIER = 'transfersharemanagementrights'
+const REVOKE_ASSET_MANAGEMENT_RIGHTS_IDENTIFIER = 'revokeassetmanagementrights'
+
+export const PROCEDURE_TYPE_TRANSFER = 'transfer' as const
+export const PROCEDURE_TYPE_REVOKE = 'revoke' as const
+export type ManagementRightsProcedureType =
+  | typeof PROCEDURE_TYPE_TRANSFER
+  | typeof PROCEDURE_TYPE_REVOKE
+
+type ManagementRightsProcedureResult = {
+  procedure: SmartContractProcedure
+  type: ManagementRightsProcedureType
+}
+
+const findProcedureByIdentifier = (
+  contract: SmartContract,
+  identifier: string,
+): SmartContractProcedure | undefined => {
+  return contract.procedures.find((p) => p.sourceIdentifier?.toLowerCase() === identifier)
+}
 
 /**
- * Checks if a smart contract has the "Transfer Share Management Rights" procedure.
+ * Finds any management rights procedure (transfer or revoke) on a contract.
+ * Returns the procedure and its type, preferring transfer over revoke.
+ */
+export const findManagementRightsProcedure = (
+  contract: SmartContract,
+): ManagementRightsProcedureResult | undefined => {
+  const transferProc = findProcedureByIdentifier(
+    contract,
+    TRANSFER_SHARE_MANAGEMENT_RIGHTS_IDENTIFIER,
+  )
+  if (transferProc) return { procedure: transferProc, type: PROCEDURE_TYPE_TRANSFER }
+  const revokeProc = findProcedureByIdentifier(contract, REVOKE_ASSET_MANAGEMENT_RIGHTS_IDENTIFIER)
+  if (revokeProc) return { procedure: revokeProc, type: PROCEDURE_TYPE_REVOKE }
+  return undefined
+}
+
+/**
+ * Checks if a smart contract has any management rights procedure (transfer or revoke).
  * Used to determine if the contract can be a SOURCE.
  */
-export const hasTransferRightsProcedure = (contract: SmartContract): boolean => {
-  return contract.procedures.some(
-    (p) => p.name.toLowerCase() === TRANSFER_SHARE_MANAGEMENT_RIGHTS_PROCEDURE.toLowerCase(),
-  )
+export const hasManagementRightsProcedure = (contract: SmartContract): boolean => {
+  return findManagementRightsProcedure(contract) !== undefined
 }
 
 /**
  * Checks if a smart contract can receive transferred share management rights.
- * Used to filter DESTINATION contracts.
+ * Used to filter DESTINATION contracts for transfer operations.
  */
 export const canReceiveTransferShares = (contract: SmartContract): boolean => {
   return contract.allowTransferShares === true
 }
 
 /**
- * Finds the "Transfer Share Management Rights" procedure on a contract.
+ * Writes the common payload prefix shared by transfer and revoke operations.
+ *
+ *   [0..31]   issuer public key          (32 bytes)
+ *   [32..39]  asset name (UTF-8, padded) ( 8 bytes)
+ *   [40..47]  numberOfShares (int64 LE)  ( 8 bytes)
  */
-export const findTransferRightsProcedure = (
-  contract: SmartContract,
-): SmartContractProcedure | undefined => {
-  return contract.procedures.find(
-    (p) => p.name.toLowerCase() === TRANSFER_SHARE_MANAGEMENT_RIGHTS_PROCEDURE.toLowerCase(),
-  )
+const writeRightsPayloadBase = (
+  payload: Uint8Array,
+  issuerIdentity: string,
+  assetName: string,
+  numberOfShares: bigint,
+): DataView => {
+  payload.set(publicKeyFromIdentity(issuerIdentity), 0)
+
+  const namePadded = new Uint8Array(8)
+  namePadded.set(new TextEncoder().encode(assetName).slice(0, 8), 0)
+  payload.set(namePadded, 32)
+
+  const view = new DataView(payload.buffer)
+  view.setBigInt64(40, numberOfShares, true)
+  return view
 }
 
 /**
- * Builds the 52-byte payload for a Transfer Share Management Rights transaction.
+ * Builds the 52-byte payload for a TransferShareManagementRights transaction.
  *
  * Layout (matches C struct TransferShareManagementRights_input):
- *   [0..31]   issuer public key              (32 bytes)
- *   [32..39]  asset name (UTF-8, padded)     ( 8 bytes)
- *   [40..47]  numberOfShares (int64 LE)      ( 8 bytes)
+ *   [0..47]   base (issuer + name + shares)  (48 bytes)
  *   [48..51]  newManagingContractIndex (u32)  ( 4 bytes)
  */
 export const buildTransferRightsPayload = (
@@ -48,18 +93,23 @@ export const buildTransferRightsPayload = (
   newManagingContractIndex: number,
 ): Uint8Array => {
   const payload = new Uint8Array(52)
-
-  const issuerKey = publicKeyFromIdentity(issuerIdentity)
-  payload.set(issuerKey, 0)
-
-  const nameBytes = new TextEncoder().encode(assetName)
-  const namePadded = new Uint8Array(8)
-  namePadded.set(nameBytes.slice(0, 8), 0)
-  payload.set(namePadded, 32)
-
-  const view = new DataView(payload.buffer)
-  view.setBigInt64(40, numberOfShares, true)
+  const view = writeRightsPayloadBase(payload, issuerIdentity, assetName, numberOfShares)
   view.setUint32(48, newManagingContractIndex, true)
+  return payload
+}
 
+/**
+ * Builds the 48-byte payload for a RevokeAssetManagementRights transaction.
+ *
+ * Layout (matches C struct RevokeAssetManagementRights_input):
+ *   [0..47]   base (issuer + name + shares)  (48 bytes)
+ */
+export const buildRevokeRightsPayload = (
+  issuerIdentity: string,
+  assetName: string,
+  numberOfShares: bigint,
+): Uint8Array => {
+  const payload = new Uint8Array(48)
+  writeRightsPayloadBase(payload, issuerIdentity, assetName, numberOfShares)
   return payload
 }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -375,6 +375,7 @@
     "noDestinationContracts": "Keine geeigneten Zielverträge verfügbar.",
     "sourceContract": "Quellvertrag",
     "sourceContractPlaceholder": "Quellvertrag auswählen",
+    "revokeOnlyHint": "* Von {{contract}} verwaltete Assets können nur an QX widerrufen werden",
     "destinationContract": "Zielvertrag",
     "destinationContractPlaceholder": "Zielvertrag auswählen",
     "numberOfSharesPlaceholder": "Gib die Menge ein",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -377,7 +377,7 @@
     "sourceContractPlaceholder": "Quellvertrag auswählen",
     "destinationContract": "Zielvertrag",
     "destinationContractPlaceholder": "Zielvertrag auswählen",
-    "numberOfSharesPlaceholder": "Anzahl der Anteile eingeben",
+    "numberOfSharesPlaceholder": "Gib die Menge ein",
     "available": "Verfügbar: {{balance}} {{token}}",
     "fee": "Gebühr: {{fee}} QUBIC",
     "quBalance": "Kontostand: {{balance}} QUBIC",
@@ -385,9 +385,10 @@
       "title": "Rechteübertragung bestätigen",
       "description": "Überprüfe die Details vor der Übertragung der Verwaltungsrechte.",
       "asset": "Vermögenswert",
+      "issuedBy": "Ausgegeben von {{issuer}}",
       "from": "Von Vertrag",
       "to": "Zu Vertrag",
-      "shares": "Anteile",
+      "amount": "Menge",
       "feeLabel": "Gebühr",
       "warning": "Diese Aktion kann nicht rückgängig gemacht werden."
     },
@@ -395,9 +396,9 @@
       "sourceRequired": "Quellvertrag ist erforderlich.",
       "destinationRequired": "Zielvertrag ist erforderlich.",
       "sameContract": "Quell- und Zielvertrag müssen unterschiedlich sein.",
-      "sharesRequired": "Anzahl der Anteile ist erforderlich.",
-      "sharesInvalid": "Anzahl der Anteile muss eine positive Zahl sein.",
-      "sharesExceedsBalance": "Anzahl der Anteile übersteigt das verfügbare Guthaben.",
+      "sharesRequired": "Menge ist erforderlich.",
+      "sharesInvalid": "Menge muss eine positive Zahl sein.",
+      "sharesExceedsBalance": "Menge übersteigt das verfügbare Guthaben.",
       "insufficientQuForFee": "Unzureichendes QUBIC-Guthaben zur Deckung der {{fee}} QU Gebühr."
     },
     "actions": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -375,6 +375,7 @@
     "noDestinationContracts": "No eligible destination contracts available.",
     "sourceContract": "Source contract",
     "sourceContractPlaceholder": "Select source contract",
+    "revokeOnlyHint": "* Assets managed by {{contract}} can only be revoked to QX",
     "destinationContract": "Destination contract",
     "destinationContractPlaceholder": "Select destination contract",
     "numberOfSharesPlaceholder": "Enter the amount",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -377,7 +377,7 @@
     "sourceContractPlaceholder": "Select source contract",
     "destinationContract": "Destination contract",
     "destinationContractPlaceholder": "Select destination contract",
-    "numberOfSharesPlaceholder": "Enter number of shares",
+    "numberOfSharesPlaceholder": "Enter the amount",
     "available": "Available: {{balance}} {{token}}",
     "fee": "Fee: {{fee}} QUBIC",
     "quBalance": "Balance: {{balance}} QUBIC",
@@ -385,9 +385,10 @@
       "title": "Confirm transfer rights",
       "description": "Review the details before transferring management rights.",
       "asset": "Asset",
+      "issuedBy": "Issued by {{issuer}}",
       "from": "From contract",
       "to": "To contract",
-      "shares": "Shares",
+      "amount": "Amount",
       "feeLabel": "Fee",
       "warning": "This action cannot be undone."
     },
@@ -395,9 +396,9 @@
       "sourceRequired": "Source contract is required.",
       "destinationRequired": "Destination contract is required.",
       "sameContract": "Source and destination must be different contracts.",
-      "sharesRequired": "Number of shares is required.",
-      "sharesInvalid": "Number of shares must be a positive number.",
-      "sharesExceedsBalance": "Number of shares exceeds available balance.",
+      "sharesRequired": "Amount is required.",
+      "sharesInvalid": "Amount must be a positive number.",
+      "sharesExceedsBalance": "Amount exceeds available balance.",
       "insufficientQuForFee": "Insufficient QUBIC balance to cover the {{fee}} QU fee."
     },
     "actions": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -375,6 +375,7 @@
     "noDestinationContracts": "No hay contratos de destino elegibles disponibles.",
     "sourceContract": "Contrato de origen",
     "sourceContractPlaceholder": "Seleccionar contrato de origen",
+    "revokeOnlyHint": "* Los activos gestionados por {{contract}} solo pueden ser revocados a QX",
     "destinationContract": "Contrato de destino",
     "destinationContractPlaceholder": "Seleccionar contrato de destino",
     "numberOfSharesPlaceholder": "Ingresa la cantidad",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -377,7 +377,7 @@
     "sourceContractPlaceholder": "Seleccionar contrato de origen",
     "destinationContract": "Contrato de destino",
     "destinationContractPlaceholder": "Seleccionar contrato de destino",
-    "numberOfSharesPlaceholder": "Ingresa el número de participaciones",
+    "numberOfSharesPlaceholder": "Ingresa la cantidad",
     "available": "Disponible: {{balance}} {{token}}",
     "fee": "Comisión: {{fee}} QUBIC",
     "quBalance": "Saldo: {{balance}} QUBIC",
@@ -385,9 +385,10 @@
       "title": "Confirmar transferencia de derechos",
       "description": "Revisa los detalles antes de transferir los derechos de gestión.",
       "asset": "Activo",
+      "issuedBy": "Emitido por {{issuer}}",
       "from": "Desde contrato",
       "to": "Hacia contrato",
-      "shares": "Participaciones",
+      "amount": "Cantidad",
       "feeLabel": "Comisión",
       "warning": "Esta acción no se puede deshacer."
     },
@@ -395,9 +396,9 @@
       "sourceRequired": "El contrato de origen es requerido.",
       "destinationRequired": "El contrato de destino es requerido.",
       "sameContract": "El origen y destino deben ser contratos diferentes.",
-      "sharesRequired": "El número de participaciones es requerido.",
-      "sharesInvalid": "El número de participaciones debe ser un número positivo.",
-      "sharesExceedsBalance": "El número de participaciones excede el saldo disponible.",
+      "sharesRequired": "La cantidad es requerida.",
+      "sharesInvalid": "La cantidad debe ser un número positivo.",
+      "sharesExceedsBalance": "La cantidad excede el saldo disponible.",
       "insufficientQuForFee": "Saldo QUBIC insuficiente para cubrir la comisión de {{fee}} QU."
     },
     "actions": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -377,7 +377,7 @@
     "sourceContractPlaceholder": "Sélectionner le contrat source",
     "destinationContract": "Contrat de destination",
     "destinationContractPlaceholder": "Sélectionner le contrat de destination",
-    "numberOfSharesPlaceholder": "Entrer le nombre de parts",
+    "numberOfSharesPlaceholder": "Entrez le montant",
     "available": "Disponible : {{balance}} {{token}}",
     "fee": "Frais : {{fee}} QUBIC",
     "quBalance": "Solde : {{balance}} QUBIC",
@@ -385,9 +385,10 @@
       "title": "Confirmer le transfert de droits",
       "description": "Vérifiez les détails avant de transférer les droits de gestion.",
       "asset": "Actif",
+      "issuedBy": "Émis par {{issuer}}",
       "from": "Du contrat",
       "to": "Vers le contrat",
-      "shares": "Parts",
+      "amount": "Montant",
       "feeLabel": "Frais",
       "warning": "Cette action est irréversible."
     },
@@ -395,9 +396,9 @@
       "sourceRequired": "Le contrat source est requis.",
       "destinationRequired": "Le contrat de destination est requis.",
       "sameContract": "Les contrats source et de destination doivent être différents.",
-      "sharesRequired": "Le nombre de parts est requis.",
-      "sharesInvalid": "Le nombre de parts doit être un nombre positif.",
-      "sharesExceedsBalance": "Le nombre de parts dépasse le solde disponible.",
+      "sharesRequired": "Le montant est requis.",
+      "sharesInvalid": "Le montant doit être un nombre positif.",
+      "sharesExceedsBalance": "Le montant dépasse le solde disponible.",
       "insufficientQuForFee": "Solde QUBIC insuffisant pour couvrir les frais de {{fee}} QU."
     },
     "actions": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -375,6 +375,7 @@
     "noDestinationContracts": "Aucun contrat de destination éligible disponible.",
     "sourceContract": "Contrat source",
     "sourceContractPlaceholder": "Sélectionner le contrat source",
+    "revokeOnlyHint": "* Les actifs gérés par {{contract}} ne peuvent être révoqués que vers QX",
     "destinationContract": "Contrat de destination",
     "destinationContractPlaceholder": "Sélectionner le contrat de destination",
     "numberOfSharesPlaceholder": "Entrez le montant",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -375,6 +375,7 @@
     "noDestinationContracts": "Нет доступных контрактов назначения.",
     "sourceContract": "Исходный контракт",
     "sourceContractPlaceholder": "Выберите исходный контракт",
+    "revokeOnlyHint": "* Активы, управляемые {{contract}}, могут быть отозваны только в QX",
     "destinationContract": "Контракт назначения",
     "destinationContractPlaceholder": "Выберите контракт назначения",
     "numberOfSharesPlaceholder": "Введите количество",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -377,7 +377,7 @@
     "sourceContractPlaceholder": "Выберите исходный контракт",
     "destinationContract": "Контракт назначения",
     "destinationContractPlaceholder": "Выберите контракт назначения",
-    "numberOfSharesPlaceholder": "Введите количество долей",
+    "numberOfSharesPlaceholder": "Введите количество",
     "available": "Доступно: {{balance}} {{token}}",
     "fee": "Комиссия: {{fee}} QUBIC",
     "quBalance": "Баланс: {{balance}} QUBIC",
@@ -385,9 +385,10 @@
       "title": "Подтвердить передачу прав",
       "description": "Проверьте детали перед передачей прав управления.",
       "asset": "Актив",
+      "issuedBy": "Выпущено {{issuer}}",
       "from": "Из контракта",
       "to": "В контракт",
-      "shares": "Доли",
+      "amount": "Количество",
       "feeLabel": "Комиссия",
       "warning": "Это действие нельзя отменить."
     },
@@ -395,9 +396,9 @@
       "sourceRequired": "Необходимо указать исходный контракт.",
       "destinationRequired": "Необходимо указать контракт назначения.",
       "sameContract": "Исходный и целевой контракты должны быть разными.",
-      "sharesRequired": "Необходимо указать количество долей.",
-      "sharesInvalid": "Количество долей должно быть положительным числом.",
-      "sharesExceedsBalance": "Количество долей превышает доступный баланс.",
+      "sharesRequired": "Количество обязательно.",
+      "sharesInvalid": "Количество должно быть положительным числом.",
+      "sharesExceedsBalance": "Количество превышает доступный баланс.",
       "insufficientQuForFee": "Недостаточно QUBIC для покрытия комиссии в {{fee}} QU."
     },
     "actions": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -377,7 +377,7 @@
     "sourceContractPlaceholder": "Kaynak sözleşmeyi seçin",
     "destinationContract": "Hedef sözleşme",
     "destinationContractPlaceholder": "Hedef sözleşmeyi seçin",
-    "numberOfSharesPlaceholder": "Pay sayısını girin",
+    "numberOfSharesPlaceholder": "Miktarı girin",
     "available": "Kullanılabilir: {{balance}} {{token}}",
     "fee": "Ücret: {{fee}} QUBIC",
     "quBalance": "Bakiye: {{balance}} QUBIC",
@@ -385,9 +385,10 @@
       "title": "Hak transferini onayla",
       "description": "Yönetim haklarını transfer etmeden önce detayları gözden geçirin.",
       "asset": "Varlık",
+      "issuedBy": "{{issuer}} tarafından yayınlandı",
       "from": "Kaynak sözleşme",
       "to": "Hedef sözleşme",
-      "shares": "Paylar",
+      "amount": "Miktar",
       "feeLabel": "Ücret",
       "warning": "Bu işlem geri alınamaz."
     },
@@ -395,9 +396,9 @@
       "sourceRequired": "Kaynak sözleşme gereklidir.",
       "destinationRequired": "Hedef sözleşme gereklidir.",
       "sameContract": "Kaynak ve hedef farklı sözleşmeler olmalıdır.",
-      "sharesRequired": "Pay sayısı gereklidir.",
-      "sharesInvalid": "Pay sayısı pozitif bir sayı olmalıdır.",
-      "sharesExceedsBalance": "Pay sayısı kullanılabilir bakiyeyi aşıyor.",
+      "sharesRequired": "Miktar gereklidir.",
+      "sharesInvalid": "Miktar pozitif bir sayı olmalıdır.",
+      "sharesExceedsBalance": "Miktar mevcut bakiyeyi aşıyor.",
       "insufficientQuForFee": "{{fee}} QU ücreti için yeterli QUBIC bakiyesi yok."
     },
     "actions": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -375,6 +375,7 @@
     "noDestinationContracts": "Uygun hedef sözleşme bulunamadı.",
     "sourceContract": "Kaynak sözleşme",
     "sourceContractPlaceholder": "Kaynak sözleşmeyi seçin",
+    "revokeOnlyHint": "* {{contract}} tarafından yönetilen varlıklar yalnızca QX'e iptal edilebilir",
     "destinationContract": "Hedef sözleşme",
     "destinationContractPlaceholder": "Hedef sözleşmeyi seçin",
     "numberOfSharesPlaceholder": "Miktarı girin",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -375,6 +375,7 @@
     "noDestinationContracts": "Không có hợp đồng đích đủ điều kiện.",
     "sourceContract": "Hợp đồng nguồn",
     "sourceContractPlaceholder": "Chọn hợp đồng nguồn",
+    "revokeOnlyHint": "* Tài sản được quản lý bởi {{contract}} chỉ có thể thu hồi về QX",
     "destinationContract": "Hợp đồng đích",
     "destinationContractPlaceholder": "Chọn hợp đồng đích",
     "numberOfSharesPlaceholder": "Nhập số lượng",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -377,7 +377,7 @@
     "sourceContractPlaceholder": "Chọn hợp đồng nguồn",
     "destinationContract": "Hợp đồng đích",
     "destinationContractPlaceholder": "Chọn hợp đồng đích",
-    "numberOfSharesPlaceholder": "Nhập số lượng cổ phần",
+    "numberOfSharesPlaceholder": "Nhập số lượng",
     "available": "Khả dụng: {{balance}} {{token}}",
     "fee": "Phí: {{fee}} QUBIC",
     "quBalance": "Số dư: {{balance}} QUBIC",
@@ -385,9 +385,10 @@
       "title": "Xác nhận chuyển quyền",
       "description": "Xem lại chi tiết trước khi chuyển quyền quản lý.",
       "asset": "Tài sản",
+      "issuedBy": "Phát hành bởi {{issuer}}",
       "from": "Từ hợp đồng",
       "to": "Đến hợp đồng",
-      "shares": "Cổ phần",
+      "amount": "Số lượng",
       "feeLabel": "Phí",
       "warning": "Hành động này không thể hoàn tác."
     },
@@ -395,9 +396,9 @@
       "sourceRequired": "Yêu cầu hợp đồng nguồn.",
       "destinationRequired": "Yêu cầu hợp đồng đích.",
       "sameContract": "Hợp đồng nguồn và đích phải khác nhau.",
-      "sharesRequired": "Yêu cầu số lượng cổ phần.",
-      "sharesInvalid": "Số lượng cổ phần phải là số dương.",
-      "sharesExceedsBalance": "Số lượng cổ phần vượt quá số dư khả dụng.",
+      "sharesRequired": "Số lượng là bắt buộc.",
+      "sharesInvalid": "Số lượng phải là số dương.",
+      "sharesExceedsBalance": "Số lượng vượt quá số dư khả dụng.",
       "insufficientQuForFee": "Không đủ số dư QUBIC để trang trải phí {{fee}} QU."
     },
     "actions": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -377,7 +377,7 @@
     "sourceContractPlaceholder": "选择来源合约",
     "destinationContract": "目标合约",
     "destinationContractPlaceholder": "选择目标合约",
-    "numberOfSharesPlaceholder": "输入份额数量",
+    "numberOfSharesPlaceholder": "输入数量",
     "available": "可用：{{balance}} {{token}}",
     "fee": "手续费：{{fee}} QUBIC",
     "quBalance": "余额：{{balance}} QUBIC",
@@ -385,9 +385,10 @@
       "title": "确认权限转移",
       "description": "转移管理权限前请核实以下详情。",
       "asset": "资产",
+      "issuedBy": "由 {{issuer}} 发行",
       "from": "来源合约",
       "to": "目标合约",
-      "shares": "份额",
+      "amount": "数量",
       "feeLabel": "手续费",
       "warning": "此操作无法撤销。"
     },
@@ -395,9 +396,9 @@
       "sourceRequired": "请选择来源合约。",
       "destinationRequired": "请选择目标合约。",
       "sameContract": "来源合约和目标合约不能相同。",
-      "sharesRequired": "请输入份额数量。",
-      "sharesInvalid": "份额数量必须为正数。",
-      "sharesExceedsBalance": "份额数量超出可用余额。",
+      "sharesRequired": "数量为必填项。",
+      "sharesInvalid": "数量必须为正数。",
+      "sharesExceedsBalance": "数量超过可用余额。",
       "insufficientQuForFee": "QUBIC 余额不足以支付 {{fee}} QU 的手续费。"
     },
     "actions": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -375,6 +375,7 @@
     "noDestinationContracts": "没有可用的目标合约。",
     "sourceContract": "来源合约",
     "sourceContractPlaceholder": "选择来源合约",
+    "revokeOnlyHint": "* 由 {{contract}} 管理的资产只能撤销到 QX",
     "destinationContract": "目标合约",
     "destinationContractPlaceholder": "选择目标合约",
     "numberOfSharesPlaceholder": "输入数量",

--- a/src/pages/asset-detail.tsx
+++ b/src/pages/asset-detail.tsx
@@ -8,6 +8,7 @@ import { useCurrentIdentity } from '@/hooks/use-current-identity'
 import { useClipboardCopy } from '@/hooks/use-clipboard-copy'
 import { formatAssetUnits, getAssetsPerContract, useOwnedAssets } from '@/lib/assets'
 import { useSmartContracts } from '@/lib/qubic-static'
+import { hasManagementRightsProcedure } from '@/lib/transfer-rights'
 import { compareBigIntDesc, truncateString } from '@/lib/utils'
 import { HIDDEN_BALANCE, useBalanceVisibility } from '@/lib/balance-visibility'
 
@@ -15,6 +16,7 @@ type ContractBreakdown = {
   contractIndex: number
   contractName: string
   numberOfUnits: string
+  hasManagementRights: boolean
 }
 
 const AssetDetail = () => {
@@ -29,9 +31,12 @@ const AssetDetail = () => {
   const { isVisible } = useBalanceVisibility()
 
   const contractsMap = useMemo(() => {
-    const map = new Map<number, string>()
+    const map = new Map<number, { name: string; hasManagementRights: boolean }>()
     for (const sc of smartContracts.data ?? []) {
-      map.set(sc.contractIndex, sc.name)
+      map.set(sc.contractIndex, {
+        name: sc.name,
+        hasManagementRights: hasManagementRightsProcedure(sc),
+      })
     }
     return map
   }, [smartContracts.data])
@@ -54,15 +59,19 @@ const AssetDetail = () => {
     const totalUnits = matching.reduce((sum, c) => sum + BigInt(c.numberOfUnits), 0n).toString()
 
     const breakdown: ContractBreakdown[] = matching
-      .map((entry) => ({
-        contractIndex: entry.managingContractIndex,
-        contractName:
-          contractsMap.get(entry.managingContractIndex) ??
-          t('assetDetail.unknownContract', {
-            index: entry.managingContractIndex,
-          }),
-        numberOfUnits: entry.numberOfUnits,
-      }))
+      .map((entry) => {
+        const sc = contractsMap.get(entry.managingContractIndex)
+        return {
+          contractIndex: entry.managingContractIndex,
+          contractName:
+            sc?.name ??
+            t('assetDetail.unknownContract', {
+              index: entry.managingContractIndex,
+            }),
+          numberOfUnits: entry.numberOfUnits,
+          hasManagementRights: sc?.hasManagementRights ?? false,
+        }
+      })
       .sort((a, b) => compareBigIntDesc(a.numberOfUnits, b.numberOfUnits))
 
     return {
@@ -184,14 +193,16 @@ const AssetDetail = () => {
                       : HIDDEN_BALANCE}
                   </div>
                 </div>
-                <TransferRightsButton
-                  className="ml-2"
-                  onClick={() =>
-                    navigate(
-                      `/transfer/manage-rights?asset=${encodeURIComponent(decodedAssetKey)}&contractIndex=${contract.contractIndex}`,
-                    )
-                  }
-                />
+                {contract.hasManagementRights && (
+                  <TransferRightsButton
+                    className="ml-2"
+                    onClick={() =>
+                      navigate(
+                        `/transfer/manage-rights?asset=${encodeURIComponent(decodedAssetKey)}&contractIndex=${contract.contractIndex}`,
+                      )
+                    }
+                  />
+                )}
               </div>
             ))}
           </div>

--- a/src/pages/transfer-rights.tsx
+++ b/src/pages/transfer-rights.tsx
@@ -373,7 +373,6 @@ const TransferRights = () => {
           parsedShares,
         )
       } else {
-        if (!destinationContract) return
         payload = buildTransferRightsPayload(
           selectedGroup.issuerIdentity,
           selectedGroup.name,
@@ -626,6 +625,13 @@ const TransferRights = () => {
               )}
               {errors.destinationContract && (
                 <p className="text-xs text-destructive">{errors.destinationContract}</p>
+              )}
+              {sourceContract?.procedureType === PROCEDURE_TYPE_REVOKE && (
+                <p className="text-xs text-muted-foreground">
+                  {t('transferRights.revokeOnlyHint', {
+                    contract: sourceContract.contractName,
+                  })}
+                </p>
               )}
             </div>
 

--- a/src/pages/transfer-rights.tsx
+++ b/src/pages/transfer-rights.tsx
@@ -27,14 +27,17 @@ import PassphraseAuth from '@/pages/passphrase-auth'
 import { isWatchOnlyIdentity } from '@/lib/accounts'
 import { useCurrentIdentity } from '@/hooks/use-current-identity'
 import { formatAssetUnits, getAssetsPerContract, useOwnedAssets } from '@/lib/assets'
-import { QX_CONTRACT_INDEX } from '@/lib/config/constants'
 import { useSmartContracts } from '@/lib/qubic-static'
 import type { SmartContract } from '@/lib/qubic-static.types'
+import { QX_CONTRACT_INDEX } from '@/lib/config/constants'
+import type { ManagementRightsProcedureType } from '@/lib/transfer-rights'
 import {
+  PROCEDURE_TYPE_REVOKE,
+  buildRevokeRightsPayload,
   buildTransferRightsPayload,
   canReceiveTransferShares,
-  findTransferRightsProcedure,
-  hasTransferRightsProcedure,
+  findManagementRightsProcedure,
+  hasManagementRightsProcedure,
 } from '@/lib/transfer-rights'
 import { addPendingTransaction, PENDING_SETTLED_EVENT } from '@/lib/pending-transactions'
 import { isWalletLocked } from '@/lib/lock'
@@ -45,6 +48,7 @@ import {
   formatNumber,
   normalizeBalance,
   parseAmount,
+  truncateString,
 } from '@/lib/utils'
 
 type Step = 'select-asset' | 'form' | 'auth'
@@ -52,6 +56,7 @@ type FormErrors = {
   sourceContract?: string
   destinationContract?: string
   shares?: string
+  fee?: string
   targetTick?: string
 }
 
@@ -66,6 +71,7 @@ type AssetGroup = {
     numberOfUnits: string
     procedureId: number
     procedureFee: number
+    procedureType: ManagementRightsProcedureType
   }>
 }
 
@@ -112,11 +118,11 @@ const TransferRights = () => {
   const onChainQuBalance = normalizeBalance(balance.data?.balance)
   const currentTick = tickInfo.data?.tickInfo?.tick
 
-  // Build source-eligible contracts map (contracts that have the procedure)
+  // Build source-eligible contracts map (contracts that have a management rights procedure)
   const contractsMap = useMemo(() => {
     const map = new Map<number, SmartContract>()
     for (const sc of smartContracts.data ?? []) {
-      if (hasTransferRightsProcedure(sc)) {
+      if (hasManagementRightsProcedure(sc)) {
         map.set(sc.contractIndex, sc)
       }
     }
@@ -134,8 +140,8 @@ const TransferRights = () => {
       const contract = contractsMap.get(entry.managingContractIndex)
       if (!contract) continue
 
-      const procedure = findTransferRightsProcedure(contract)
-      if (!procedure || procedure.fee === undefined || procedure.fee < 0) continue
+      const result = findManagementRightsProcedure(contract)
+      if (!result || result.procedure.fee == null || result.procedure.fee < 0) continue
 
       const key = `${entry.issuerIdentity}-${entry.name}`
       let group = groupMap.get(key)
@@ -154,8 +160,9 @@ const TransferRights = () => {
         contractName: contract.name,
         contractAddress: contract.address,
         numberOfUnits: entry.numberOfUnits,
-        procedureId: procedure.id,
-        procedureFee: procedure.fee,
+        procedureId: result.procedure.id,
+        procedureFee: result.procedure.fee,
+        procedureType: result.type,
       })
     }
 
@@ -174,13 +181,25 @@ const TransferRights = () => {
     (c) => c.contractIndex === selectedSourceIndex,
   )
 
-  // Destination options: contracts with allowTransferShares, excluding the source
+  // Destination options depend on source contract's procedure type:
+  // - revoke: destination is only QX
+  // - transfer: destination is contracts with allowTransferShares + management rights procedure
   const destinationOptions = useMemo(() => {
     if (!smartContracts.data || selectedSourceIndex === null) return []
+
+    if (sourceContract?.procedureType === PROCEDURE_TYPE_REVOKE) {
+      return smartContracts.data.filter((sc) => sc.contractIndex === QX_CONTRACT_INDEX)
+    }
+
     return smartContracts.data
-      .filter((sc) => canReceiveTransferShares(sc) && sc.contractIndex !== selectedSourceIndex)
+      .filter(
+        (sc) =>
+          canReceiveTransferShares(sc) &&
+          hasManagementRightsProcedure(sc) &&
+          sc.contractIndex !== selectedSourceIndex,
+      )
       .sort((a, b) => a.name.localeCompare(b.name))
-  }, [smartContracts.data, selectedSourceIndex])
+  }, [smartContracts.data, selectedSourceIndex, sourceContract?.procedureType])
 
   const destinationContract = destinationOptions.find(
     (sc) => sc.contractIndex === selectedDestIndex,
@@ -196,11 +215,8 @@ const TransferRights = () => {
 
   useEffect(() => {
     if (selectedSourceIndex === null || selectedDestIndex !== null) return
-    if (selectedSourceIndex !== QX_CONTRACT_INDEX) {
-      const qx = destinationOptions.find((sc) => sc.contractIndex === QX_CONTRACT_INDEX)
-      if (qx) {
-        setSelectedDestIndex(QX_CONTRACT_INDEX)
-      }
+    if (destinationOptions.length === 1) {
+      setSelectedDestIndex(destinationOptions[0].contractIndex)
     }
   }, [selectedSourceIndex, selectedDestIndex, destinationOptions])
 
@@ -257,7 +273,7 @@ const TransferRights = () => {
     if (sourceContract) {
       const fee = BigInt(sourceContract.procedureFee)
       if (onChainQuBalance < fee) {
-        newErrors.shares = t('transferRights.validation.insufficientQuForFee', {
+        newErrors.fee = t('transferRights.validation.insufficientQuForFee', {
           fee: sourceContract.procedureFee.toString(),
         })
       }
@@ -304,6 +320,8 @@ const TransferRights = () => {
     const seed = seedArg ?? seedRef.current
     if (!seed || !sourceContract || !destinationContract || !selectedGroup) return
 
+    const isRevoke = sourceContract.procedureType === PROCEDURE_TYPE_REVOKE
+
     setSending(true)
     setErrorMessage('')
 
@@ -347,12 +365,22 @@ const TransferRights = () => {
         throw new Error(t('transferRights.errors.networkError'))
       }
 
-      const payload = buildTransferRightsPayload(
-        selectedGroup.issuerIdentity,
-        selectedGroup.name,
-        parsedShares,
-        destinationContract.contractIndex,
-      )
+      let payload: Uint8Array
+      if (isRevoke) {
+        payload = buildRevokeRightsPayload(
+          selectedGroup.issuerIdentity,
+          selectedGroup.name,
+          parsedShares,
+        )
+      } else {
+        if (!destinationContract) return
+        payload = buildTransferRightsPayload(
+          selectedGroup.issuerIdentity,
+          selectedGroup.name,
+          parsedShares,
+          destinationContract.contractIndex,
+        )
+      }
 
       const result = await sdk.transactions.send({
         fromSeed: seed,
@@ -516,6 +544,11 @@ const TransferRights = () => {
             {selectedGroup && (
               <div className="rounded-lg border border-border/40 px-3 py-2 text-sm font-medium text-foreground">
                 {selectedGroup.name}
+                <span className="ml-2 text-xs font-normal text-muted-foreground">
+                  {t('transferRights.confirm.issuedBy', {
+                    issuer: truncateString(selectedGroup.issuerIdentity),
+                  })}
+                </span>
               </div>
             )}
 
@@ -529,9 +562,7 @@ const TransferRights = () => {
                 onValueChange={(value) => {
                   const idx = Number(value)
                   setSelectedSourceIndex(idx)
-                  if (selectedDestIndex === idx) {
-                    setSelectedDestIndex(null)
-                  }
+                  setSelectedDestIndex(null)
                   setShares('')
                   setErrors((prev) => ({
                     ...prev,
@@ -642,13 +673,16 @@ const TransferRights = () => {
 
             {/* Fee info */}
             {sourceContract && (
-              <div className="rounded-lg border border-border/40 px-3 py-2 text-xs text-muted-foreground">
-                <div>
-                  {t('transferRights.fee', { fee: sourceContract.procedureFee.toString() })}
+              <div className="space-y-1.5">
+                <div className="rounded-lg border border-border/40 px-3 py-2 text-xs text-muted-foreground">
+                  <div>
+                    {t('transferRights.fee', { fee: sourceContract.procedureFee.toString() })}
+                  </div>
+                  <div>
+                    {t('transferRights.quBalance', { balance: formatBalance(onChainQuBalance) })}
+                  </div>
                 </div>
-                <div>
-                  {t('transferRights.quBalance', { balance: formatBalance(onChainQuBalance) })}
-                </div>
+                {errors.fee && <p className="text-xs text-destructive">{errors.fee}</p>}
               </div>
             )}
 
@@ -789,10 +823,21 @@ const TransferRights = () => {
 
           <div className="flex-1 space-y-4 overflow-y-auto px-4 pb-2">
             <div className="space-y-3">
-              <SummaryRow
-                label={t('transferRights.confirm.asset')}
-                value={selectedGroup?.name ?? ''}
-              />
+              <div className="space-y-1 first:border-t-0 first:pt-0">
+                <div className="text-[11px] font-semibold uppercase tracking-[0.15em] text-muted-foreground">
+                  {t('transferRights.confirm.asset')}
+                </div>
+                <div className="text-sm text-foreground">
+                  {selectedGroup?.name}
+                  {selectedGroup && (
+                    <span className="ml-1.5 text-xs text-muted-foreground">
+                      {t('transferRights.confirm.issuedBy', {
+                        issuer: truncateString(selectedGroup.issuerIdentity),
+                      })}
+                    </span>
+                  )}
+                </div>
+              </div>
               <SummaryRow
                 label={t('transferRights.confirm.from')}
                 value={sourceContract?.contractName ?? ''}
@@ -802,9 +847,8 @@ const TransferRights = () => {
                 value={destinationContract?.name ?? ''}
               />
               <SummaryRow
-                label={t('transferRights.confirm.shares')}
+                label={t('transferRights.confirm.amount')}
                 value={`${formatAssetUnits(String(parseAmount(shares) ?? 0n), selectedGroup?.decimals)} ${selectedTokenLabel}`}
-                emphasize
               />
               {sourceContract && (
                 <SummaryRow

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -150,7 +150,7 @@ const Transfer = () => {
           newErrors.amount = t('transfer.validation.amountExceedsBalance')
         }
         if (onChainQuBalance < QX_TRANSFER_ASSET_FEE) {
-          newErrors.amount = t('transfer.validation.insufficientQuForFee', { fee: '100' })
+          newErrors.fee = t('transfer.validation.insufficientQuForFee', { fee: '100' })
         }
       } else if (balance.isLoading) {
         newErrors.amount = t('transfer.validation.balanceLoading')


### PR DESCRIPTION
Add RevokeAssetManagementRights procedure support alongside existing TransferShareManagementRights using sourceIdentifier-based matching. Rename "shares" to "amount" across all 8 locales, add "Issued by" issuer hint in gray, and move insufficient QU fee error below the fee info box in both transfer and transfer-rights flows.