### PR TITLE
fix(ui): show account name in reveal seed drawer

### DIFF
--- a/src/components/pages/manage-accounts/reveal-seed-drawer.tsx
+++ b/src/components/pages/manage-accounts/reveal-seed-drawer.tsx
@@ -17,10 +17,11 @@ import { useClipboardCopy } from '@/hooks/use-clipboard-copy'
 type RevealSeedDrawerProps = {
   open: boolean
   seed: string
+  accountName: string
   onOpenChange: (open: boolean) => void
 }
 
-const RevealSeedDrawer = ({ open, seed, onOpenChange }: RevealSeedDrawerProps) => {
+const RevealSeedDrawer = ({ open, seed, accountName, onOpenChange }: RevealSeedDrawerProps) => {
   const { t } = useTranslation()
   const { copyText } = useClipboardCopy()
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null)
@@ -53,7 +54,7 @@ const RevealSeedDrawer = ({ open, seed, onOpenChange }: RevealSeedDrawerProps) =
     <Drawer open={open} onOpenChange={onOpenChange}>
       <DrawerContent>
         <DrawerHeader>
-          <DrawerTitle>{t('accounts.manage.revealTitle')}</DrawerTitle>
+          <DrawerTitle>{t('accounts.manage.revealTitle', { name: accountName })}</DrawerTitle>
         </DrawerHeader>
         <div className="flex flex-col items-center gap-4 px-4">
           {qrDataUrl && (

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -89,7 +89,7 @@ function DrawerTitle({ className, ...props }: React.ComponentProps<typeof Drawer
   return (
     <DrawerPrimitive.Title
       data-slot="drawer-title"
-      className={cn('text-foreground font-semibold', className)}
+      className={cn('text-foreground text-lg font-semibold', className)}
       {...props}
     />
   )

--- a/src/pages/manage-accounts.tsx
+++ b/src/pages/manage-accounts.tsx
@@ -493,6 +493,7 @@ const ManageAccounts = () => {
       <RevealSeedDrawer
         open={Boolean(seedTarget)}
         seed={revealedSeed}
+        accountName={seedTarget?.name ?? ''}
         onOpenChange={(open) => {
           if (!open) {
             setSeedTarget(null)


### PR DESCRIPTION
## Summary
- Display the account name in the reveal seed drawer title to clarify which account's private seed is being shown
- Bump `DrawerTitle` base font size to `text-lg` globally