### PR TITLE
fix: remove tabular-nums from asset balances

### DIFF
--- a/src/pages/asset-detail.tsx
+++ b/src/pages/asset-detail.tsx
@@ -132,7 +132,7 @@ const AssetDetail = () => {
             </div>
             <div className="min-w-0 flex-1">
               <div className="text-lg font-semibold text-foreground">{asset.name}</div>
-              <div className="text-2xl font-bold tabular-nums text-foreground">
+              <div className="text-2xl font-bold text-foreground">
                 {isVisible ? formatAssetUnits(asset.totalUnits, asset.decimals) : HIDDEN_BALANCE}
               </div>
             </div>

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -297,7 +297,7 @@ const Home = () => {
                         )}
                       </div>
                       <div className="ml-3 flex shrink-0 items-center gap-2">
-                        <span className="text-right text-base font-semibold tabular-nums text-foreground">
+                        <span className="text-right text-base font-semibold text-foreground">
                           {isVisible
                             ? formatAssetUnits(asset.numberOfUnits, asset.decimals)
                             : HIDDEN_BALANCE}


### PR DESCRIPTION
## Summary
- Remove `tabular-nums` from asset balance text in home page and asset detail page
- Space Grotesk renders tabular figures with a baseline serif on "1", making asset balances visually inconsistent with the rest of the app