### PR TITLE
fix: use transfer-rights icon from wallet-app

### DIFF
--- a/src/components/icons/transfer-rights-icon.tsx
+++ b/src/components/icons/transfer-rights-icon.tsx
@@ -1,0 +1,35 @@
+const TransferRightsIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    {...props}
+  >
+    <path
+      d="M4 4C4 2.89543 4.89543 2 6 2H11L16 7V16C16 17.1046 15.1046 18 14 18H6C4.89543 18 4 17.1046 4 16V4Z"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      fill="none"
+    />
+    <path
+      d="M11 2V7H16"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M7 12H12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    <path
+      d="M10 10L12 12L10 14"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+)
+
+export { TransferRightsIcon }

--- a/src/components/transfer-rights-button.tsx
+++ b/src/components/transfer-rights-button.tsx
@@ -1,6 +1,6 @@
-import { ArrowRightLeftIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
+import { TransferRightsIcon } from '@/components/icons/transfer-rights-icon'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
@@ -21,7 +21,7 @@ const TransferRightsButton = ({ onClick, className }: TransferRightsButtonProps)
           className={cn('h-8 w-8 shrink-0 text-muted-foreground', className)}
           onClick={onClick}
         >
-          <ArrowRightLeftIcon className="h-3.5 w-3.5" />
+          <TransferRightsIcon className="h-3.5 w-3.5" />
         </Button>
       </TooltipTrigger>
       <TooltipContent>{t('assetDetail.transferRights')}</TooltipContent>


### PR DESCRIPTION
## Summary
- Replace `ArrowRightLeftIcon` (lucide) with custom `TransferRightsIcon` matching the icon used in wallet and wallet-app projects
- New icon component follows existing pattern (`send-icon.tsx`, `receive-icon.tsx`) — uses `currentColor` for theme adaptability