### PR TITLE
fix: prevent duplicate vault entries when renaming accounts

### DIFF
--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -1,8 +1,10 @@
 import {
   type SeedVault,
+  type VaultSummary,
   type VaultStore,
   createLocalStorageVaultStore,
   openSeedVaultBrowser,
+  VaultEntryExistsError,
   VaultEntryNotFoundError,
   VaultInvalidPassphraseError,
 } from '@qubic-labs/sdk'
@@ -124,6 +126,100 @@ export const validateVaultPassphrase = async (
     }
     return { valid: false, reason: 'error' }
   }
+}
+
+type VaultAccountEntry = {
+  name: string
+  identity: string
+}
+
+const toTimestamp = (value: string): number => {
+  const parsed = Date.parse(value)
+  return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY
+}
+
+const compareVaultEntries = (
+  left: VaultSummary & { index: number },
+  right: VaultSummary & { index: number },
+) => {
+  const updatedDiff = toTimestamp(left.updatedAt) - toTimestamp(right.updatedAt)
+  if (updatedDiff !== 0) return updatedDiff
+
+  const createdDiff = toTimestamp(left.createdAt) - toTimestamp(right.createdAt)
+  if (createdDiff !== 0) return createdDiff
+
+  return left.index - right.index
+}
+
+const mapVaultAccounts = (entries: readonly VaultSummary[]): VaultAccountEntry[] =>
+  entries.map((entry) => ({ name: entry.name, identity: entry.identity }))
+
+export const repairDuplicateVaultEntries = async (
+  vault: SeedVault,
+): Promise<VaultAccountEntry[]> => {
+  const indexedEntries = vault.list().map((entry, index) => ({ ...entry, index }))
+  const entriesByIdentity = new Map<string, Array<VaultSummary & { index: number }>>()
+
+  for (const entry of indexedEntries) {
+    const existing = entriesByIdentity.get(entry.identity)
+    if (existing) {
+      existing.push(entry)
+    } else {
+      entriesByIdentity.set(entry.identity, [entry])
+    }
+  }
+
+  const duplicateEntriesToRemove: VaultSummary[] = []
+  for (const entries of entriesByIdentity.values()) {
+    if (entries.length <= 1) continue
+    let keeper = entries[0]
+    for (const entry of entries.slice(1)) {
+      if (compareVaultEntries(entry, keeper) > 0) {
+        keeper = entry
+      }
+    }
+    duplicateEntriesToRemove.push(...entries.filter((entry) => entry.name !== keeper.name))
+  }
+
+  if (duplicateEntriesToRemove.length === 0) {
+    return mapVaultAccounts(vault.list())
+  }
+
+  for (const entry of duplicateEntriesToRemove) {
+    await vault.remove(entry.name)
+  }
+  await vault.save()
+
+  return mapVaultAccounts(vault.list())
+}
+
+export const renameVaultAccountByIdentity = async (
+  vault: SeedVault,
+  identity: string,
+  nextName: string,
+): Promise<VaultAccountEntry[]> => {
+  const normalizedName = nextName.trim()
+  const entries = vault.list()
+  const currentEntry = entries.find((entry) => entry.identity === identity)
+  if (!currentEntry) {
+    throw new VaultEntryNotFoundError(identity)
+  }
+
+  const conflictingEntry = entries.find((entry) => entry.name === normalizedName)
+  if (conflictingEntry && conflictingEntry.identity !== identity) {
+    throw new VaultEntryExistsError(normalizedName)
+  }
+
+  if (currentEntry.name === normalizedName) {
+    return repairDuplicateVaultEntries(vault)
+  }
+
+  const seed = await vault.getSeed(identity)
+  await vault.remove(currentEntry.name)
+  await vault.addSeed({ name: normalizedName, seed, overwrite: false })
+  await vault.save()
+
+  return repairDuplicateVaultEntries(vault)
 }
 
 export const setOnboarded = (identity: string, name?: string) => {

--- a/src/lib/vault.ts
+++ b/src/lib/vault.ts
@@ -200,8 +200,8 @@ export const renameVaultAccountByIdentity = async (
 ): Promise<VaultAccountEntry[]> => {
   const normalizedName = nextName.trim()
   const entries = vault.list()
-  const currentEntry = entries.find((entry) => entry.identity === identity)
-  if (!currentEntry) {
+  const entriesForIdentity = entries.filter((entry) => entry.identity === identity)
+  if (entriesForIdentity.length === 0) {
     throw new VaultEntryNotFoundError(identity)
   }
 
@@ -210,13 +210,17 @@ export const renameVaultAccountByIdentity = async (
     throw new VaultEntryExistsError(normalizedName)
   }
 
-  if (currentEntry.name === normalizedName) {
+  const alreadyNamedEntry = entriesForIdentity.find((entry) => entry.name === normalizedName)
+  if (alreadyNamedEntry) {
     return repairDuplicateVaultEntries(vault)
   }
 
   const seed = await vault.getSeed(identity)
-  await vault.remove(currentEntry.name)
-  await vault.addSeed({ name: normalizedName, seed, overwrite: false })
+  await vault.addSeed({ name: normalizedName, seed, overwrite: true })
+  for (const entry of entriesForIdentity) {
+    if (entry.name === normalizedName) continue
+    await vault.remove(entry.name)
+  }
   await vault.save()
 
   return repairDuplicateVaultEntries(vault)

--- a/src/pages/manage-accounts.tsx
+++ b/src/pages/manage-accounts.tsx
@@ -295,12 +295,6 @@ const ManageAccounts = () => {
           setOnboarded(account.identity, name.trim())
         }
       }
-      if (account.watchOnly) {
-        const updated = orderedAccounts.map((entry) =>
-          entry.identity === account.identity ? { ...entry, name: name.trim() } : entry,
-        )
-        saveCachedAccounts(updated.filter((entry) => !entry.watchOnly))
-      }
       setRenameTarget(null)
       setRenameValue('')
       setRenameError('')

--- a/src/pages/manage-accounts.tsx
+++ b/src/pages/manage-accounts.tsx
@@ -15,7 +15,13 @@ import {
   saveCachedAccounts,
   saveWatchOnlyAccounts,
 } from '@/lib/accounts'
-import { clearOnboarded, openBrowserVault, setOnboarded } from '@/lib/vault'
+import {
+  clearOnboarded,
+  openBrowserVault,
+  renameVaultAccountByIdentity,
+  repairDuplicateVaultEntries,
+  setOnboarded,
+} from '@/lib/vault'
 import AccountListItem from '@/components/pages/manage-accounts/account-list-item'
 import AddAccountDrawer from '@/components/pages/manage-accounts/add-account-drawer'
 import RenameAccountDrawer from '@/components/pages/manage-accounts/rename-account-drawer'
@@ -147,10 +153,7 @@ const ManageAccounts = () => {
     setLoading(true)
     try {
       const vault = await openBrowserVault(passphrase, false)
-      const entries = vault.list().map((entry) => ({
-        name: entry.name,
-        identity: entry.identity,
-      }))
+      const entries = await repairDuplicateVaultEntries(vault)
       saveCachedAccounts(entries)
       const watchOnly = getWatchOnlyAccounts()
       const merged = [
@@ -268,24 +271,36 @@ const ManageAccounts = () => {
           entry.identity === account.identity ? { ...entry, name: name.trim() } : entry,
         )
         saveWatchOnlyAccounts(watchOnly)
+        const updated = orderedAccounts.map((entry) =>
+          entry.identity === account.identity ? { ...entry, name: name.trim() } : entry,
+        )
+        setAccounts(updated)
         if (account.identity === currentIdentity) {
           setOnboarded(account.identity, name.trim())
         }
       } else {
         const vault = await openBrowserVault(passphrase, false)
-        const seed = await vault.getSeed(account.identity)
-        // Write first with overwrite to avoid losing the existing entry if an intermediate step fails.
-        await vault.addSeed({ name: name.trim(), seed, overwrite: true })
-        await vault.save()
+        const entries = await renameVaultAccountByIdentity(vault, account.identity, name.trim())
+        saveCachedAccounts(entries)
+        const watchOnly = getWatchOnlyAccounts()
+        setAccounts([
+          ...entries,
+          ...watchOnly.map((entry) => ({
+            name: entry.name,
+            identity: entry.identity,
+            watchOnly: true as const,
+          })),
+        ])
         if (account.identity === currentIdentity) {
           setOnboarded(account.identity, name.trim())
         }
       }
-      const updated = orderedAccounts.map((entry) =>
-        entry.identity === account.identity ? { ...entry, name: name.trim() } : entry,
-      )
-      saveCachedAccounts(updated.filter((entry) => !entry.watchOnly))
-      setAccounts(updated)
+      if (account.watchOnly) {
+        const updated = orderedAccounts.map((entry) =>
+          entry.identity === account.identity ? { ...entry, name: name.trim() } : entry,
+        )
+        saveCachedAccounts(updated.filter((entry) => !entry.watchOnly))
+      }
       setRenameTarget(null)
       setRenameValue('')
       setRenameError('')

--- a/src/pages/unlock.tsx
+++ b/src/pages/unlock.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/ui/button'
 import { PasswordInput } from '@/components/ui/password-input'
 import { setUnlocked } from '@/lib/lock'
 import { saveCachedAccounts } from '@/lib/accounts'
-import { openBrowserVault } from '@/lib/vault'
+import { openBrowserVault, repairDuplicateVaultEntries } from '@/lib/vault'
 
 const Unlock = () => {
   const { t } = useTranslation()
@@ -34,7 +34,8 @@ const Unlock = () => {
       }
 
       await vault.getSeed(identityToValidate)
-      saveCachedAccounts(vault.list().map((e) => ({ name: e.name, identity: e.identity })))
+      const entries = await repairDuplicateVaultEntries(vault)
+      saveCachedAccounts(entries)
       setUnlocked()
       setPassphrase('')
       navigate('/home')


### PR DESCRIPTION
## Summary
- rename vault accounts by identity instead of relying on name-based overwrite behavior
- automatically repair duplicate vault entries that share the same identity during trusted vault-open flows
- refresh cached accounts from the normalized vault list after rename, unlock, and manual load

## Verification
- npm run lint
- npm run build

Fixes #112