### PR TITLE
feat: add formatted number input for amounts and target tick

### DIFF
--- a/src/components/numeric-input.tsx
+++ b/src/components/numeric-input.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useRef, type ClipboardEvent, type ChangeEvent } from 'react'
+import { Input } from '@/components/ui/input'
+import { cn, formatNumber, parseFormattedInteger } from '@/lib/utils'
+
+type NumericInputProps = Omit<React.ComponentProps<typeof Input>, 'onChange' | 'type' | 'value'> & {
+  value: string
+  onChange: (formatted: string) => void
+}
+
+const MAX_DIGITS = 15
+
+const formatDigits = (raw: string): string => {
+  const digits = raw.replace(/\D/g, '').slice(0, MAX_DIGITS)
+  if (!digits) return ''
+  return formatNumber(BigInt(digits))
+}
+
+const countDigits = (str: string, end: number): number => {
+  let count = 0
+  for (let i = 0; i < end; i++) {
+    if (str[i] >= '0' && str[i] <= '9') count++
+  }
+  return count
+}
+
+const findCursorPosition = (formatted: string, digitIndex: number): number => {
+  let count = 0
+  for (let i = 0; i < formatted.length; i++) {
+    if (formatted[i] >= '0' && formatted[i] <= '9') {
+      count++
+      if (count === digitIndex) return i + 1
+    }
+  }
+  return formatted.length
+}
+
+const NumericInput = ({ value, onChange, className, ...props }: NumericInputProps) => {
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleChange = useCallback(
+    (e: ChangeEvent<HTMLInputElement>) => {
+      const el = e.target
+      const cursorPos = el.selectionStart ?? el.value.length
+      const digitsBefore = countDigits(el.value, cursorPos)
+      const formatted = formatDigits(el.value)
+      onChange(formatted)
+      requestAnimationFrame(() => {
+        if (!inputRef.current) return
+        const newPos = digitsBefore === 0 ? 0 : findCursorPosition(formatted, digitsBefore)
+        inputRef.current.setSelectionRange(newPos, newPos)
+      })
+    },
+    [onChange],
+  )
+
+  const handlePaste = useCallback(
+    (e: ClipboardEvent<HTMLInputElement>) => {
+      e.preventDefault()
+      const text = e.clipboardData.getData('text')
+      const parsed = parseFormattedInteger(text)
+      if (parsed === null) return
+      const capped = BigInt(parsed.toString().slice(0, MAX_DIGITS))
+      onChange(formatNumber(capped))
+    },
+    [onChange],
+  )
+
+  return (
+    <Input
+      ref={inputRef}
+      type="text"
+      inputMode="numeric"
+      value={value}
+      onChange={handleChange}
+      onPaste={handlePaste}
+      className={cn('text-right placeholder:text-left focus:placeholder:opacity-0', className)}
+      {...props}
+    />
+  )
+}
+
+export default NumericInput

--- a/src/components/pages/transfer/transfer-form.tsx
+++ b/src/components/pages/transfer/transfer-form.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import NumericInput from '@/components/numeric-input'
 import { type AggregatedAsset, formatAssetUnits } from '@/lib/assets'
 import { NATIVE_TOKEN_SYMBOL } from '@/lib/config/constants'
 import { useAddressName } from '@/hooks/use-address-name'
@@ -100,7 +101,7 @@ const TransferForm = ({
 
   const handleMax = () => {
     if (availableUnits <= 0n) return
-    onAmountChange(availableUnits.toString())
+    onAmountChange(formatNumber(availableUnits))
   }
 
   return (
@@ -186,12 +187,11 @@ const TransferForm = ({
           {/* Amount with Max + token label */}
           <div className="space-y-1.5">
             <div className="relative">
-              <Input
+              <NumericInput
                 id="amount"
-                type="text"
                 placeholder={t('transfer.form.amountPlaceholder')}
                 value={amount}
-                onChange={(e) => onAmountChange(e.target.value.replace(/[^\d,]/g, ''))}
+                onChange={onAmountChange}
                 disabled={isWatchOnly}
                 className={`h-12 pr-28 text-sm ${errors.amount ? 'border-destructive' : ''}`}
               />
@@ -279,14 +279,9 @@ const TransferForm = ({
             </div>
             {isManualTargetTickEnabled && (
               <div className="space-y-1">
-                <Input
-                  type="number"
-                  min={1}
-                  step={1}
+                <NumericInput
                   value={manualTargetTick}
-                  onChange={(event) => {
-                    onManualTargetTickChange(event.target.value)
-                  }}
+                  onChange={onManualTargetTickChange}
                   className="h-12 w-full text-sm"
                   disabled={isWatchOnly}
                   placeholder={t('transfer.form.targetTickManualPlaceholder')}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -36,6 +36,30 @@ export const parseAmount = (str: string): bigint | null => {
   return BigInt(cleaned)
 }
 
+/**
+ * Parse a formatted number string from various locale formats to an integer.
+ * Supports US (1,234), EU (1.234), and Swiss (1'234) thousand separators.
+ * Decimals are stripped (Qubic only supports integers).
+ * Returns null for invalid or empty values.
+ */
+export const parseFormattedInteger = (value: string): bigint | null => {
+  if (!value) return null
+  const trimmed = value.trim()
+  if (/^(\d{1,3}(,\d{3})*|\d+)(\.\d+)?$/.test(trimmed)) {
+    const integerPart = trimmed.split('.')[0]
+    return BigInt(integerPart.replace(/,/g, ''))
+  }
+  if (/^(\d{1,3}(\.\d{3})+|\d+)(,\d+)?$/.test(trimmed)) {
+    const integerPart = trimmed.split(',')[0]
+    return BigInt(integerPart.replace(/\./g, ''))
+  }
+  if (/^\d{1,3}('\d{3})+(\.\d+)?$/.test(trimmed)) {
+    const integerPart = trimmed.split('.')[0]
+    return BigInt(integerPart.replace(/'/g, ''))
+  }
+  return null
+}
+
 const standardFormatter = new Intl.NumberFormat('en', { notation: 'standard' })
 const compactFormatter = new Intl.NumberFormat('en', {
   notation: 'compact',

--- a/src/pages/transfer-rights.tsx
+++ b/src/pages/transfer-rights.tsx
@@ -6,7 +6,7 @@ import { useBalance, useSdk } from '@qubic-labs/react'
 import { AlertTriangleIcon, ChevronRightIcon, RouteIcon, SendIcon, XIcon } from 'lucide-react'
 import PageHeader from '@/components/page-header'
 import { Button } from '@/components/ui/button'
-import { Input } from '@/components/ui/input'
+import NumericInput from '@/components/numeric-input'
 import {
   Select,
   SelectContent,
@@ -280,7 +280,7 @@ const TransferRights = () => {
     }
 
     if (isManualTargetTickEnabled) {
-      const parsedManualTick = Number.parseInt(manualTargetTick.trim(), 10)
+      const parsedManualTick = Number(parseAmount(manualTargetTick) ?? Number.NaN)
       if (!Number.isFinite(parsedManualTick) || parsedManualTick < 1) {
         newErrors.targetTick = t('transfer.validation.targetTickManualInvalid')
       } else if (typeof currentTick === 'number' && parsedManualTick <= currentTick) {
@@ -337,7 +337,7 @@ const TransferRights = () => {
       const sendCurrentTick = freshTickInfo.tickInfo?.tick
 
       if (isManualTargetTickEnabled) {
-        const parsedManualTick = Number.parseInt(manualTargetTick.trim(), 10)
+        const parsedManualTick = Number(parseAmount(manualTargetTick) ?? Number.NaN)
         if (!Number.isFinite(parsedManualTick) || parsedManualTick < 1) {
           throw new Error(t('transfer.validation.targetTickManualInvalid'))
         }
@@ -467,7 +467,7 @@ const TransferRights = () => {
 
   const handleMax = () => {
     if (!sourceContract) return
-    setShares(sourceContract.numberOfUnits)
+    setShares(formatNumber(BigInt(sourceContract.numberOfUnits)))
   }
 
   // Asset selection screen
@@ -638,13 +638,12 @@ const TransferRights = () => {
             {/* Number of shares */}
             <div className="space-y-1.5">
               <div className="relative">
-                <Input
+                <NumericInput
                   id="shares"
-                  type="text"
                   placeholder={t('transferRights.numberOfSharesPlaceholder')}
                   value={shares}
-                  onChange={(e) => {
-                    setShares(e.target.value.replace(/[^\d,]/g, ''))
+                  onChange={(value) => {
+                    setShares(value)
                     if (errors.shares) {
                       setErrors((prev) => ({ ...prev, shares: undefined }))
                     }
@@ -732,7 +731,7 @@ const TransferRights = () => {
                   onClick={() => {
                     setIsManualTargetTickEnabled((prev) => !prev)
                     if (!isManualTargetTickEnabled && !manualTargetTick) {
-                      setManualTargetTick((currentTick ?? '').toString())
+                      setManualTargetTick(currentTick ? formatNumber(currentTick) : '')
                     }
                     if (errors.targetTick) {
                       setErrors((prev) => ({ ...prev, targetTick: undefined }))
@@ -744,13 +743,10 @@ const TransferRights = () => {
               </div>
               {isManualTargetTickEnabled && (
                 <div className="space-y-1">
-                  <Input
-                    type="number"
-                    min={1}
-                    step={1}
+                  <NumericInput
                     value={manualTargetTick}
-                    onChange={(event) => {
-                      setManualTargetTick(event.target.value)
+                    onChange={(value) => {
+                      setManualTargetTick(value)
                       if (errors.targetTick) {
                         setErrors((prev) => ({ ...prev, targetTick: undefined }))
                       }

--- a/src/pages/transfer.tsx
+++ b/src/pages/transfer.tsx
@@ -41,7 +41,7 @@ const Transfer = () => {
   const initialPrefillRecipient = (searchParams.get('recipient') ?? '').trim().toUpperCase()
   const initialPrefillAmount = (() => {
     const value = (searchParams.get('amount') ?? '').trim()
-    return /^\d+$/.test(value) ? value : ''
+    return /^\d+$/.test(value) ? formatNumber(BigInt(value)) : ''
   })()
   const selectedToken = (searchParams.get('token') ?? 'qu').trim()
   const [isWatchOnly, setIsWatchOnly] = useState(() => isWatchOnlyIdentity(getCurrentIdentity()))
@@ -162,7 +162,7 @@ const Transfer = () => {
     }
 
     if (isManualTargetTickEnabled) {
-      const parsedManualTick = Number.parseInt(manualTargetTick.trim(), 10)
+      const parsedManualTick = Number(parseAmount(manualTargetTick) ?? Number.NaN)
       if (!Number.isFinite(parsedManualTick) || parsedManualTick < 1) {
         newErrors.targetTick = t('transfer.validation.targetTickManualInvalid')
       } else if (typeof currentTick === 'number' && parsedManualTick <= currentTick) {
@@ -219,7 +219,7 @@ const Transfer = () => {
       const sendCurrentTick = freshTickInfo.tickInfo?.tick
 
       if (isManualTargetTickEnabled) {
-        const parsedManualTick = Number.parseInt(manualTargetTick.trim(), 10)
+        const parsedManualTick = Number(parseAmount(manualTargetTick) ?? Number.NaN)
         if (!Number.isFinite(parsedManualTick) || parsedManualTick < 1) {
           throw new Error(t('transfer.validation.targetTickManualInvalid'))
         }
@@ -368,7 +368,7 @@ const Transfer = () => {
   const handleManualTargetTickToggle = () => {
     setIsManualTargetTickEnabled((previous) => !previous)
     if (!isManualTargetTickEnabled && !manualTargetTick) {
-      setManualTargetTick((currentTick ?? '').toString())
+      setManualTargetTick(currentTick ? formatNumber(currentTick) : '')
     }
     if (errors.targetTick) {
       setErrors((prev) => ({ ...prev, targetTick: undefined }))


### PR DESCRIPTION
## Summary
- Add `NumericInput` component that formats numbers with thousand separators while typing
- Supports pasting from US (1,234), EU (1.234), and Swiss (1'234) locale formats
- Preserves cursor position during formatting, caps at 15 digits
- Right-aligned text with left-aligned placeholder that hides on focus
- Applied to amount, shares, and manual target tick fields in both transfer forms