### PR TITLE
feat: add deterministic account avatars across wallet account surfaces

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "@radix-ui/react-tooltip": "^1.2.8",
         "@tailwindcss/vite": "^4.1.18",
         "@tanstack/react-query": "^5.90.20",
+        "boring-avatars": "^2.0.4",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
@@ -721,6 +722,8 @@
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 
     "blakejs": ["blakejs@1.2.1", "", {}, "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="],
+
+    "boring-avatars": ["boring-avatars@2.0.4", "", { "peerDependencies": { "react": ">=18.0.0", "react-dom": ">=18.0.0" } }, "sha512-xhZO/w/6aFmRfkaWohcl2NfyIy87gK5SBbys8kctZeTGF1Apjpv/10pfUuv+YEfVPkESU/h2Y6tt/Dwp+bIZPw=="],
 
     "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@radix-ui/react-tooltip": "^1.2.8",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-query": "^5.90.20",
+    "boring-avatars": "^2.0.4",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/src/components/account-avatar.tsx
+++ b/src/components/account-avatar.tsx
@@ -1,0 +1,58 @@
+import BoringAvatar from 'boring-avatars'
+import { EyeIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const ACCOUNT_AVATAR_COLORS = [
+  '#1ADEF5',
+  '#03C1DB',
+  '#61F0FE',
+  '#0C131B',
+  '#152A38',
+  '#47CD89',
+  '#FABC3C',
+]
+
+const SIZE_STYLES = {
+  xs: { className: 'h-6 w-6', pixelSize: 24 },
+  sm: { className: 'h-8 w-8', pixelSize: 32 },
+  md: { className: 'h-10 w-10', pixelSize: 40 },
+  lg: { className: 'h-12 w-12', pixelSize: 48 },
+} as const
+
+type AccountAvatarProps = {
+  identity: string
+  name?: string
+  watchOnly?: boolean
+  size?: keyof typeof SIZE_STYLES
+  className?: string
+}
+
+const AccountAvatar = ({
+  identity,
+  name,
+  watchOnly = false,
+  size = 'md',
+  className,
+}: AccountAvatarProps) => {
+  const { className: sizeClassName, pixelSize } = SIZE_STYLES[size]
+  const avatarName = name?.trim() ? `${name}-${identity}` : identity
+
+  return (
+    <div className={cn('relative shrink-0', sizeClassName, className)}>
+      <BoringAvatar
+        size={pixelSize}
+        name={avatarName}
+        variant="marble"
+        colors={ACCOUNT_AVATAR_COLORS}
+        className="h-full w-full rounded-full border border-border/60 bg-card"
+      />
+      {watchOnly && (
+        <span className="absolute -right-0.5 -bottom-0.5 flex h-3.5 w-3.5 items-center justify-center rounded-full border border-background bg-card text-muted-foreground">
+          <EyeIcon className="h-2.5 w-2.5" />
+        </span>
+      )}
+    </div>
+  )
+}
+
+export default AccountAvatar

--- a/src/components/account-avatar.tsx
+++ b/src/components/account-avatar.tsx
@@ -13,10 +13,8 @@ const ACCOUNT_AVATAR_COLORS = [
 ]
 
 const SIZE_STYLES = {
-  xs: { className: 'h-6 w-6', pixelSize: 24 },
   sm: { className: 'h-8 w-8', pixelSize: 32 },
   md: { className: 'h-10 w-10', pixelSize: 40 },
-  lg: { className: 'h-12 w-12', pixelSize: 48 },
 } as const
 
 type AccountAvatarProps = {
@@ -42,7 +40,7 @@ const AccountAvatar = ({
       <BoringAvatar
         size={pixelSize}
         name={avatarName}
-        variant="marble"
+        variant="bauhaus"
         colors={ACCOUNT_AVATAR_COLORS}
         className="h-full w-full rounded-full border border-border/60 bg-card"
       />

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -1,12 +1,5 @@
-import {
-  CopyIcon,
-  EyeIcon,
-  PanelRightOpenIcon,
-  PlusIcon,
-  UsersIcon,
-  WalletIcon,
-  XIcon,
-} from 'lucide-react'
+import { CopyIcon, EyeIcon, PanelRightOpenIcon, PlusIcon, UsersIcon, XIcon } from 'lucide-react'
+import AccountAvatar from '@/components/account-avatar'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { formatBalanceCompact, truncateString } from '@/lib/utils'
@@ -58,6 +51,10 @@ const AppHeader = ({
     Array<{ name: string; identity: string; watchOnly?: boolean }>
   >([])
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const activeAccount = useMemo(
+    () => accounts.find((account) => account.identity === identity),
+    [accounts, identity],
+  )
 
   const refreshAccounts = useCallback(() => {
     const nextAccountName =
@@ -158,9 +155,12 @@ const AppHeader = ({
               className="flex min-w-0 items-center gap-3 text-left"
               aria-label={t('home.accounts.selectLabel')}
             >
-              <div className="flex h-10 w-10 items-center justify-center rounded-md border border-border/60 bg-card">
-                <WalletIcon className="h-5 w-5 text-primary" />
-              </div>
+              <AccountAvatar
+                identity={identity}
+                name={accountName}
+                watchOnly={activeAccount?.watchOnly}
+                size="md"
+              />
               <div className="flex min-w-0 flex-col">
                 <span
                   className="truncate text-sm font-semibold text-foreground"
@@ -213,10 +213,17 @@ const AppHeader = ({
                       key={account.identity}
                       type="button"
                       onClick={() => handleSelectAccount(account)}
-                      className={`flex w-full items-center rounded-md px-2 py-2 text-left text-sm transition hover:bg-muted/30 ${
+                      className={`flex w-full items-center gap-3 rounded-md px-2 py-2 text-left text-sm transition hover:bg-muted/30 ${
                         account.identity === identity ? 'bg-muted/20' : ''
                       }`}
                     >
+                      <AccountAvatar
+                        identity={account.identity}
+                        name={account.name}
+                        watchOnly={account.watchOnly}
+                        size="sm"
+                        className="mr-3"
+                      />
                       <div className="min-w-0 flex-1">
                         <div className="flex min-w-0 items-center gap-2">
                           <span className="min-w-0 flex-1 truncate font-medium text-foreground">

--- a/src/components/app-header.tsx
+++ b/src/components/app-header.tsx
@@ -1,4 +1,4 @@
-import { CopyIcon, EyeIcon, PanelRightOpenIcon, PlusIcon, UsersIcon, XIcon } from 'lucide-react'
+import { CopyIcon, PanelRightOpenIcon, PlusIcon, UsersIcon, XIcon } from 'lucide-react'
 import AccountAvatar from '@/components/account-avatar'
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
@@ -159,7 +159,7 @@ const AppHeader = ({
                 identity={identity}
                 name={accountName}
                 watchOnly={activeAccount?.watchOnly}
-                size="md"
+                size="sm"
               />
               <div className="flex min-w-0 flex-col">
                 <span
@@ -222,16 +222,12 @@ const AppHeader = ({
                         name={account.name}
                         watchOnly={account.watchOnly}
                         size="sm"
-                        className="mr-3"
                       />
                       <div className="min-w-0 flex-1">
                         <div className="flex min-w-0 items-center gap-2">
                           <span className="min-w-0 flex-1 truncate font-medium text-foreground">
                             {account.name}
                           </span>
-                          {account.watchOnly && (
-                            <EyeIcon className="size-3 shrink-0 text-muted-foreground" />
-                          )}
                           {account.identity === identity && (
                             <span className="shrink-0 text-[11px] text-primary">
                               {t('accounts.manage.active')}

--- a/src/components/dapp/dapp-approval-drawer.tsx
+++ b/src/components/dapp/dapp-approval-drawer.tsx
@@ -3,6 +3,7 @@ import { useDrawerAutoFocus } from '@/hooks/use-drawer-auto-focus'
 import { useTranslation } from 'react-i18next'
 import { useLocation } from 'react-router-dom'
 import { ChevronDownIcon, ChevronUpIcon, GlobeIcon, Link2OffIcon, LinkIcon } from 'lucide-react'
+import AccountAvatar from '@/components/account-avatar'
 import { Button } from '@/components/ui/button'
 import {
   Drawer,
@@ -292,15 +293,24 @@ const DappApprovalDrawer = () => {
                 <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
                   {t('dapp.approval.sharedAccount')}
                 </p>
-                <p
-                  className="truncate text-sm font-medium text-foreground"
-                  title={connectSummary.accountName}
-                >
-                  {connectSummary.accountName || t('dapp.approval.sharedAccountFallback')}
-                </p>
-                <p className="truncate font-mono text-xs text-muted-foreground">
-                  {truncateString(connectSummary.accountIdentity)}
-                </p>
+                <div className="mt-2 flex items-center gap-3">
+                  <AccountAvatar
+                    identity={connectSummary.accountIdentity}
+                    name={connectSummary.accountName}
+                    size="md"
+                  />
+                  <div className="min-w-0">
+                    <p
+                      className="truncate text-sm font-medium text-foreground"
+                      title={connectSummary.accountName}
+                    >
+                      {connectSummary.accountName || t('dapp.approval.sharedAccountFallback')}
+                    </p>
+                    <p className="truncate font-mono text-xs text-muted-foreground">
+                      {truncateString(connectSummary.accountIdentity)}
+                    </p>
+                  </div>
+                </div>
               </div>
             )}
             {current.method === 'signMessage' && (
@@ -384,15 +394,25 @@ const DappApprovalDrawer = () => {
               )}
             {isWatchOnlySigningRequest && accountSummary && (
               <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 p-3">
-                <p className="text-sm font-medium text-foreground">
-                  {t('dapp.approval.watchOnlyTitle')}
-                </p>
-                <p className="mt-1 break-words text-sm text-muted-foreground">
-                  {t('dapp.approval.watchOnlyDescription', {
-                    accountName:
-                      accountSummary.accountName || t('dapp.approval.sharedAccountFallback'),
-                  })}
-                </p>
+                <div className="flex items-center gap-3">
+                  <AccountAvatar
+                    identity={accountSummary.accountIdentity}
+                    name={accountSummary.accountName}
+                    watchOnly={accountSummary.accountWatchOnly}
+                    size="md"
+                  />
+                  <div className="min-w-0">
+                    <p className="text-sm font-medium text-foreground">
+                      {t('dapp.approval.watchOnlyTitle')}
+                    </p>
+                    <p className="mt-1 break-words text-sm text-muted-foreground">
+                      {t('dapp.approval.watchOnlyDescription', {
+                        accountName:
+                          accountSummary.accountName || t('dapp.approval.sharedAccountFallback'),
+                      })}
+                    </p>
+                  </div>
+                </div>
               </div>
             )}
             {requiresPassphrase && !isWatchOnlySigningRequest && (

--- a/src/components/pages/manage-accounts/account-list-item.tsx
+++ b/src/components/pages/manage-accounts/account-list-item.tsx
@@ -8,6 +8,7 @@ import {
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { KeyVerticalIcon } from '@/components/icons/key-vertical-icon'
+import AccountAvatar from '@/components/account-avatar'
 import { Button } from '@/components/ui/button'
 import {
   DropdownMenu,
@@ -75,38 +76,46 @@ const AccountListItem = ({
         isOver ? 'ring-2 ring-primary/40' : ''
       } ${isDragging ? 'opacity-60' : ''}`}
     >
-      <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 items-start justify-between gap-2">
-          <div className="min-w-0">
-            <span className="block truncate text-sm font-semibold text-foreground">
-              {account.name}
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <AccountAvatar
+          identity={account.identity}
+          name={account.name}
+          watchOnly={account.watchOnly}
+          size="sm"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 items-start justify-between gap-2">
+            <div className="min-w-0">
+              <span className="block truncate text-sm font-semibold text-foreground">
+                {account.name}
+              </span>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              {account.watchOnly && (
+                <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-700 dark:text-amber-200">
+                  <EyeIcon className="h-2.5 w-2.5" />
+                  {t('accounts.manage.watchOnly')}
+                </span>
+              )}
+              {isActive && (
+                <span className="shrink-0 text-[11px] text-primary">
+                  {t('accounts.manage.active')}
+                </span>
+              )}
+            </div>
+          </div>
+          <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
+            <span className="truncate">
+              {truncateString(account.identity, { leading: 5, trailing: 5 })}
+            </span>
+            <span className="text-[11px] font-semibold text-foreground">
+              {isVisible
+                ? balance !== undefined
+                  ? formatBalanceCompact(balance)
+                  : '--'
+                : HIDDEN_BALANCE}
             </span>
           </div>
-          <div className="flex shrink-0 items-center gap-2">
-            {account.watchOnly && (
-              <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-amber-500/30 bg-amber-500/10 px-1.5 py-0.5 text-[10px] text-amber-700 dark:text-amber-200">
-                <EyeIcon className="h-2.5 w-2.5" />
-                {t('accounts.manage.watchOnly')}
-              </span>
-            )}
-            {isActive && (
-              <span className="shrink-0 text-[11px] text-primary">
-                {t('accounts.manage.active')}
-              </span>
-            )}
-          </div>
-        </div>
-        <div className="flex items-center justify-between gap-2 text-xs text-muted-foreground">
-          <span className="truncate">
-            {truncateString(account.identity, { leading: 5, trailing: 5 })}
-          </span>
-          <span className="text-[11px] font-semibold text-foreground">
-            {isVisible
-              ? balance !== undefined
-                ? formatBalanceCompact(balance)
-                : '--'
-              : HIDDEN_BALANCE}
-          </span>
         </div>
       </div>
       <div className="flex items-center gap-1">


### PR DESCRIPTION
## Summary

Implements issue #88 by introducing deterministic account avatars and showing them anywhere users choose or review wallet accounts.

### What changed

- Added `boring-avatars` dependency.
- Added a reusable `AccountAvatar` component:
  - Deterministic by account identity (+ name seed fallback behavior already supported in component)
  - Uses wallet-aligned palette centered on primary cyan (`#1ADEF5`) with complementary tones
  - Uses `marble` variant
  - Supports watch-only badge overlay
- Replaced generic account icon / text-only account rows with avatars in:
  - App header active account selector
  - Home account dropdown list
  - Manage Accounts list items
  - dApp approval drawer account sections

### UX details

- Avatars are consistent across views for the same account identity.
- Watch-only accounts preserve their visual indicator.
- Spacing in the home dropdown account rows was adjusted so avatar/text alignment is clear.

## Validation

- `bun run lint` ✅
- `bun run build` ✅

## Related

- Closes #88