### PR TITLE
fix: make pin button behave consistently in popup and side panel

### DIFF
--- a/src/components/app-shell.tsx
+++ b/src/components/app-shell.tsx
@@ -8,6 +8,7 @@ import { ArrowLeftRightIcon, HistoryIcon, HomeIcon, SettingsIcon } from 'lucide-
 import AppHeader from '@/components/app-header'
 import DappApprovalDrawer from '@/components/dapp/dapp-approval-drawer'
 import { getWatchOnlyAccounts } from '@/lib/accounts'
+import { getExtensionViewKind, toggleCurrentWindowSidePanel } from '@/lib/side-panel'
 
 const AppShell = ({
   children,
@@ -16,10 +17,8 @@ const AppShell = ({
 }: PropsWithChildren<{ showNav?: boolean; showHeader?: boolean }>) => {
   const { t } = useTranslation()
   const { pathname } = useLocation()
-  const isPopupView =
-    typeof window !== 'undefined' && window.location.pathname.endsWith('popup.html')
-  const isSidePanelView =
-    typeof window !== 'undefined' && window.location.pathname.endsWith('sidepanel.html')
+  const extensionViewKind = getExtensionViewKind()
+  const isSidePanelView = extensionViewKind === 'sidepanel'
   const scrollContainerRef = useRef<HTMLDivElement | null>(null)
   const navRef = useRef<HTMLElement | null>(null)
   const navItemRefs = useRef<Array<HTMLAnchorElement | null>>([])
@@ -53,51 +52,8 @@ const AppShell = ({
     }
   }, [])
 
-  const openSidePanel = async () => {
-    const chromeApi = (
-      globalThis as typeof globalThis & {
-        chrome?: {
-          sidePanel?: { open?: (options: { windowId?: number }) => Promise<void> }
-          windows?: { getCurrent?: () => Promise<{ id?: number }>; WINDOW_ID_CURRENT?: number }
-        }
-      }
-    ).chrome
-
-    if (!chromeApi?.sidePanel?.open) {
-      return
-    }
-
-    let windowId: number | undefined
-
-    if (chromeApi.windows?.getCurrent) {
-      try {
-        const currentWindow = await chromeApi.windows.getCurrent()
-        windowId = currentWindow.id
-      } catch {
-        windowId = undefined
-      }
-    }
-
-    if (windowId == null) {
-      windowId = chromeApi.windows?.WINDOW_ID_CURRENT
-    }
-
-    if (windowId == null) {
-      return
-    }
-
-    await chromeApi.sidePanel.open({ windowId })
-  }
-
   const toggleSidePanel = async () => {
-    if (isSidePanelView) {
-      window.close()
-      return
-    }
-    await openSidePanel()
-    if (isPopupView) {
-      window.close()
-    }
+    await toggleCurrentWindowSidePanel()
   }
 
   const navItems = useMemo(

--- a/src/lib/side-panel.ts
+++ b/src/lib/side-panel.ts
@@ -1,0 +1,75 @@
+type ChromeSidePanelApi = {
+  open?: (options: { windowId?: number }) => Promise<void>
+  close?: (options: { windowId?: number }) => Promise<void>
+}
+
+type ChromeWindowsApi = {
+  getCurrent?: () => Promise<{ id?: number }>
+  WINDOW_ID_CURRENT?: number
+}
+
+type ChromeApi = {
+  sidePanel?: ChromeSidePanelApi
+  windows?: ChromeWindowsApi
+}
+
+export const getExtensionViewKind = (): 'popup' | 'sidepanel' | 'other' => {
+  if (typeof window === 'undefined') return 'other'
+  const { pathname } = window.location
+  if (pathname.endsWith('popup.html')) return 'popup'
+  if (pathname.endsWith('sidepanel.html')) return 'sidepanel'
+  return 'other'
+}
+
+const getChromeApi = (): ChromeApi | undefined =>
+  (
+    globalThis as typeof globalThis & {
+      chrome?: ChromeApi
+    }
+  ).chrome
+
+const getCurrentWindowId = async (chromeApi: ChromeApi): Promise<number | undefined> => {
+  if (chromeApi.windows?.getCurrent) {
+    try {
+      const currentWindow = await chromeApi.windows.getCurrent()
+      if (currentWindow.id != null) return currentWindow.id
+    } catch {
+      // Fallback below when Chrome cannot resolve the current window id.
+    }
+  }
+
+  return chromeApi.windows?.WINDOW_ID_CURRENT
+}
+
+export const toggleCurrentWindowSidePanel = async (): Promise<void> => {
+  const chromeApi = getChromeApi()
+  const viewKind = getExtensionViewKind()
+
+  if (!chromeApi?.sidePanel) {
+    if (viewKind === 'sidepanel') {
+      window.close()
+    }
+    return
+  }
+
+  const windowId = await getCurrentWindowId(chromeApi)
+
+  if (viewKind === 'sidepanel') {
+    if (windowId != null && chromeApi.sidePanel.close) {
+      await chromeApi.sidePanel.close({ windowId })
+      return
+    }
+    window.close()
+    return
+  }
+
+  if (!chromeApi.sidePanel.open || windowId == null) {
+    return
+  }
+
+  await chromeApi.sidePanel.open({ windowId })
+
+  if (viewKind === 'popup') {
+    requestAnimationFrame(() => window.close())
+  }
+}

--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -3,47 +3,13 @@ import { useNavigate } from 'react-router-dom'
 import { useTheme } from 'next-themes'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
+import { getExtensionViewKind, toggleCurrentWindowSidePanel } from '@/lib/side-panel'
 
 const Welcome = () => {
   const navigate = useNavigate()
   const { resolvedTheme } = useTheme()
   const { t } = useTranslation()
-
-  const openSidePanel = async () => {
-    const chromeApi = (
-      globalThis as typeof globalThis & {
-        chrome?: {
-          sidePanel?: { open?: (options: { windowId?: number }) => Promise<void> }
-          windows?: { getCurrent?: () => Promise<{ id?: number }>; WINDOW_ID_CURRENT?: number }
-        }
-      }
-    ).chrome
-
-    if (!chromeApi?.sidePanel?.open) {
-      return
-    }
-
-    let windowId: number | undefined
-
-    if (chromeApi.windows?.getCurrent) {
-      try {
-        const currentWindow = await chromeApi.windows.getCurrent()
-        windowId = currentWindow.id
-      } catch {
-        windowId = undefined
-      }
-    }
-
-    if (windowId == null) {
-      windowId = chromeApi.windows?.WINDOW_ID_CURRENT
-    }
-
-    if (windowId == null) {
-      return
-    }
-
-    await chromeApi.sidePanel.open({ windowId })
-  }
+  const isSidePanelView = getExtensionViewKind() === 'sidepanel'
 
   return (
     <section className="flex h-full flex-col items-center justify-center gap-6 px-6 text-center">
@@ -89,8 +55,8 @@ const Welcome = () => {
         size="icon"
         variant="ghost"
         className="absolute right-4 top-4 h-10 w-10"
-        aria-label={t('app.sidepanel')}
-        onClick={openSidePanel}
+        aria-label={isSidePanelView ? t('app.closeSidepanel') : t('app.sidepanel')}
+        onClick={toggleCurrentWindowSidePanel}
       >
         <PanelRightOpenIcon className="h-5 w-5" />
       </Button>


### PR DESCRIPTION
## Summary
- centralize side panel open/close behavior in a shared helper
- make the welcome screen use the same side panel toggle flow as the main app shell
- close the popup after opening the side panel and close the side panel when toggled from within it

## Validation
- npm run lint
- npm run build