### PR TITLE
feat: show smart contract icon next to identified addresses

### DIFF
--- a/src/components/address-label.tsx
+++ b/src/components/address-label.tsx
@@ -1,4 +1,5 @@
 import { useAddressName } from '@/hooks/use-address-name'
+import { SmartContractIcon } from '@/components/icons/smart-contract-icon'
 import { truncateString } from '@/lib/utils'
 
 type AddressLabelProps = {
@@ -12,9 +13,14 @@ const AddressLabel = ({ address, className, prefix }: AddressLabelProps) => {
 
   if (resolved) {
     return (
-      <span className={className}>
+      <span className={`inline-flex items-center gap-1 ${className ?? ''}`}>
         {prefix && `${prefix} `}
-        {resolved.name} <span className="font-mono">({truncateString(address)})</span>
+        {resolved.type === 'smartContract' && (
+          <SmartContractIcon className="h-3.5 w-3.5 shrink-0" />
+        )}
+        <span className="truncate">
+          {resolved.name} <span className="font-mono">({truncateString(address)})</span>
+        </span>
       </span>
     )
   }

--- a/src/components/icons/smart-contract-icon.tsx
+++ b/src/components/icons/smart-contract-icon.tsx
@@ -1,0 +1,19 @@
+const SmartContractIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth="1.5"
+    stroke="currentColor"
+    aria-hidden="true"
+    {...props}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+    />
+  </svg>
+)
+
+export { SmartContractIcon }

--- a/src/components/pages/transaction-details/tx-details-row.tsx
+++ b/src/components/pages/transaction-details/tx-details-row.tsx
@@ -1,8 +1,9 @@
 import type React from 'react'
+import { isValidElement } from 'react'
 import { CheckIcon, CopyIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
-const formatValue = (value: unknown): string => {
+const formatValueAsString = (value: unknown): string => {
   if (value === null || value === undefined) return '--'
   if (typeof value === 'bigint') return value.toString()
   if (typeof value === 'object') {
@@ -13,6 +14,11 @@ const formatValue = (value: unknown): string => {
     }
   }
   return String(value)
+}
+
+const formatValue = (value: unknown): React.ReactNode => {
+  if (isValidElement(value)) return value
+  return formatValueAsString(value)
 }
 
 type TxDetailsRowProps = {
@@ -61,4 +67,4 @@ const TxDetailsRow = ({ row, copiedKey, onCopy }: TxDetailsRowProps) => {
 }
 
 export default TxDetailsRow
-export { formatValue }
+export { formatValue, formatValueAsString }

--- a/src/pages/transaction-details.tsx
+++ b/src/pages/transaction-details.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircleIcon,
   XCircleFilledIcon,
 } from '@/components/icons/tx-status-icons'
+import { SmartContractIcon } from '@/components/icons/smart-contract-icon'
 import type React from 'react'
 import { useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
@@ -22,7 +23,9 @@ import { useClipboardCopy } from '@/hooks/use-clipboard-copy'
 import { formatAddressLabel, formatIntegerLike, formatNumber, toTimestampMs } from '@/lib/utils'
 import { NATIVE_TOKEN_SYMBOL } from '@/lib/config/constants'
 import TxDetailsHeader from '@/components/pages/transaction-details/tx-details-header'
-import TxDetailsRow, { formatValue } from '@/components/pages/transaction-details/tx-details-row'
+import TxDetailsRow, {
+  formatValueAsString,
+} from '@/components/pages/transaction-details/tx-details-row'
 
 const TX_DETAILS_SKELETON_IDS = ['a', 'b', 'c', 'd', 'e', 'f'] as const
 
@@ -146,16 +149,34 @@ const TransactionDetails = () => {
     {
       key: 'source',
       label: t('txDetails.source'),
-      value: sourceName
-        ? formatAddressLabel(sourceAddress, sourceName.name)
-        : sourceAddress || '--',
+      value:
+        sourceName?.type === 'smartContract' ? (
+          <span className="inline-flex items-center gap-1">
+            <SmartContractIcon className="h-3.5 w-3.5 shrink-0" />
+            {formatAddressLabel(sourceAddress, sourceName.name)}
+          </span>
+        ) : sourceName ? (
+          formatAddressLabel(sourceAddress, sourceName.name)
+        ) : (
+          sourceAddress || '--'
+        ),
       copyable: Boolean(sourceAddress),
       copyText: sourceAddress,
     },
     {
       key: 'destination',
       label: t('txDetails.destination'),
-      value: destName ? formatAddressLabel(destAddress, destName.name) : destAddress || '--',
+      value:
+        destName?.type === 'smartContract' ? (
+          <span className="inline-flex items-center gap-1">
+            <SmartContractIcon className="h-3.5 w-3.5 shrink-0" />
+            {formatAddressLabel(destAddress, destName.name)}
+          </span>
+        ) : destName ? (
+          formatAddressLabel(destAddress, destName.name)
+        ) : (
+          destAddress || '--'
+        ),
       copyable: Boolean(destAddress),
       copyText: destAddress,
     },
@@ -172,7 +193,7 @@ const TransactionDetails = () => {
   ]
 
   const copyValue = async (key: string, value: unknown, rawText?: string) => {
-    await copyText(rawText ?? formatValue(value), { key })
+    await copyText(rawText ?? formatValueAsString(value), { key })
   }
 
   return (


### PR DESCRIPTION
Display an inline document icon next to addresses that are identified as smart contracts. The icon appears in transaction history, home preview, dapp approval, and transaction detail views. Uses the same SVG from the explorer-frontend for visual consistency.