### PR TITLE
fix: prevent popup layout overflow across wallet flows

### DIFF
--- a/src/components/dapp/dapp-approval-drawer.tsx
+++ b/src/components/dapp/dapp-approval-drawer.tsx
@@ -248,11 +248,11 @@ const DappApprovalDrawer = () => {
       <DrawerContent
         className={
           isDappApprovalPopup
-            ? 'inset-0 h-full max-h-none rounded-none border-none bg-background data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-none data-[vaul-drawer-direction=bottom]:rounded-none data-[vaul-drawer-direction=bottom]:border-none'
-            : 'border-none bg-background'
+            ? 'inset-0 h-full max-h-none overflow-hidden rounded-none border-none bg-background data-[vaul-drawer-direction=bottom]:mt-0 data-[vaul-drawer-direction=bottom]:max-h-none data-[vaul-drawer-direction=bottom]:rounded-none data-[vaul-drawer-direction=bottom]:border-none'
+            : 'max-h-[90vh] overflow-hidden border-none bg-background'
         }
       >
-        <DrawerHeader className="space-y-2 text-center">
+        <DrawerHeader className="shrink-0 space-y-2 text-center">
           <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
             {faviconUrl && faviconError !== faviconUrl ? (
               <img
@@ -270,7 +270,7 @@ const DappApprovalDrawer = () => {
         </DrawerHeader>
 
         {current && (
-          <div className="space-y-3 px-4 pb-2">
+          <div className="app-scrollbar min-h-0 flex-1 space-y-3 overflow-y-auto px-4 pb-2">
             <div className="rounded-xl border border-border/60 bg-background/40 p-3">
               <p className="text-[11px] uppercase tracking-wide text-muted-foreground">
                 {t('dapp.approval.origin')}
@@ -402,7 +402,7 @@ const DappApprovalDrawer = () => {
           </div>
         )}
 
-        <DrawerFooter className="grid grid-cols-2 gap-2">
+        <DrawerFooter className="shrink-0 border-t border-border/60 bg-background grid grid-cols-2 gap-2">
           <Button
             variant="outline"
             onClick={() => void submitDecision(false)}

--- a/src/components/pages/manage-accounts/reveal-seed-drawer.tsx
+++ b/src/components/pages/manage-accounts/reveal-seed-drawer.tsx
@@ -52,22 +52,24 @@ const RevealSeedDrawer = ({ open, seed, accountName, onOpenChange }: RevealSeedD
 
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
-      <DrawerContent>
+      <DrawerContent className="max-h-[90vh] border-none bg-background">
         <DrawerHeader>
           <DrawerTitle className="break-words">
             {t('accounts.manage.revealTitle', { name: accountName })}
           </DrawerTitle>
         </DrawerHeader>
-        <div className="flex flex-col items-center gap-4 px-4">
-          {qrDataUrl && (
-            <div className="flex flex-col items-center gap-1">
-              <img src={qrDataUrl} alt={t('accounts.manage.qrAlt')} className="h-48 w-48" />
-              <p className="text-muted-foreground text-xs">{t('accounts.manage.qrLabel')}</p>
-            </div>
-          )}
-          <Textarea value={seed} rows={3} readOnly className="resize-none" />
+        <div className="app-scrollbar min-h-0 flex-1 overflow-y-auto px-4 pb-2">
+          <div className="flex flex-col items-center gap-4">
+            {qrDataUrl && (
+              <div className="flex flex-col items-center gap-1">
+                <img src={qrDataUrl} alt={t('accounts.manage.qrAlt')} className="h-48 w-48" />
+                <p className="text-muted-foreground text-xs">{t('accounts.manage.qrLabel')}</p>
+              </div>
+            )}
+            <Textarea value={seed} rows={3} readOnly className="resize-none" />
+          </div>
         </div>
-        <DrawerFooter>
+        <DrawerFooter className="border-t border-border/60 bg-background">
           <Button variant="outline" onClick={handleCopy}>
             <CopyIcon className="h-4 w-4" />
             {t('accounts.manage.copySeed')}

--- a/src/components/pages/transfer/transfer-form.tsx
+++ b/src/components/pages/transfer/transfer-form.tsx
@@ -117,8 +117,8 @@ const TransferForm = ({
   }
 
   return (
-    <section className="flex w-full justify-center">
-      <div className="flex min-h-[calc(100vh-64px)] w-full max-w-sm flex-col px-4">
+    <section className="flex w-full justify-center pt-4">
+      <div className="flex min-h-full w-full max-w-sm flex-col px-4 pb-4">
         <PageHeader
           title={
             <>
@@ -128,7 +128,7 @@ const TransferForm = ({
           onBack={() => navigate('/transfer')}
         />
         {/* Form fields */}
-        <div className="flex flex-1 flex-col gap-5">
+        <div className="flex flex-1 flex-col gap-5 pb-4">
           {/* Recipient */}
           <div ref={recipientPickerRef} className="relative space-y-1.5">
             <Input
@@ -326,7 +326,7 @@ const TransferForm = ({
         </div>
 
         {/* Bottom buttons */}
-        <div className="sticky bottom-0 flex gap-3 bg-background pb-4 pt-3">
+        <div className="sticky bottom-0 -mx-4 mt-auto flex gap-3 border-t border-border/60 bg-background px-4 pb-4 pt-3">
           <Button
             variant="outline"
             size="lg"

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -50,7 +50,7 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg',
           className,
         )}
         {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -51,7 +51,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid max-h-[calc(100dvh-2rem)] w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-y-auto rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg',
           className,
         )}
         {...props}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -46,7 +46,7 @@ function DrawerContent({
       <DrawerPrimitive.Content
         data-slot="drawer-content"
         className={cn(
-          'group/drawer-content bg-background fixed z-50 flex h-auto flex-col',
+          'group/drawer-content bg-background fixed z-50 flex h-auto flex-col overflow-hidden',
           'data-[vaul-drawer-direction=top]:inset-x-0 data-[vaul-drawer-direction=top]:top-0 data-[vaul-drawer-direction=top]:mb-24 data-[vaul-drawer-direction=top]:max-h-[90vh] data-[vaul-drawer-direction=top]:rounded-b-lg data-[vaul-drawer-direction=top]:border-b',
           'data-[vaul-drawer-direction=bottom]:inset-x-0 data-[vaul-drawer-direction=bottom]:bottom-0 data-[vaul-drawer-direction=bottom]:mt-24 data-[vaul-drawer-direction=bottom]:max-h-[90vh] data-[vaul-drawer-direction=bottom]:rounded-t-lg data-[vaul-drawer-direction=bottom]:border-t',
           'data-[vaul-drawer-direction=right]:inset-y-0 data-[vaul-drawer-direction=right]:right-0 data-[vaul-drawer-direction=right]:w-3/4 data-[vaul-drawer-direction=right]:border-l data-[vaul-drawer-direction=right]:sm:max-w-sm',
@@ -67,7 +67,7 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<'div'>) {
     <div
       data-slot="drawer-header"
       className={cn(
-        'flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left',
+        'shrink-0 flex flex-col gap-0.5 p-4 group-data-[vaul-drawer-direction=bottom]/drawer-content:text-center group-data-[vaul-drawer-direction=top]/drawer-content:text-center md:gap-1.5 md:text-left',
         className,
       )}
       {...props}
@@ -79,7 +79,7 @@ function DrawerFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return (
     <div
       data-slot="drawer-footer"
-      className={cn('mt-auto flex flex-col gap-2 p-4', className)}
+      className={cn('mt-auto shrink-0 flex flex-col gap-2 p-4', className)}
       {...props}
     />
   )

--- a/src/pages/accounts/import-watch-only.tsx
+++ b/src/pages/accounts/import-watch-only.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import PageHeader from '@/components/page-header'
 import { isValidIdentity } from '@/lib/utils'
 import {
   getWatchOnlyAccounts,
@@ -51,8 +52,8 @@ const ImportWatchOnly = () => {
   return (
     <section className="flex min-h-full w-full justify-center pb-6 pt-4">
       <div className="flex w-full max-w-sm flex-col gap-6 px-4">
-        <div className="space-y-1 text-center">
-          <h2 className="text-xl font-semibold">{t('accounts.watchOnly.title')}</h2>
+        <div className="space-y-3">
+          <PageHeader title={t('accounts.watchOnly.title')} onBack={() => navigate('/accounts')} />
           <p className="text-sm text-muted-foreground">{t('accounts.watchOnly.subtitle')}</p>
         </div>
         <div className="space-y-4">

--- a/src/pages/onboarding/create-wallet.tsx
+++ b/src/pages/onboarding/create-wallet.tsx
@@ -231,7 +231,7 @@ const CreateWallet = ({
   }
 
   return (
-    <section className="flex h-full w-full justify-center px-6 py-8">
+    <section className="flex min-h-full w-full justify-center px-6 py-8">
       <div className="flex w-full max-w-sm flex-col justify-between gap-6">
         <div className="space-y-3 text-center">
           <FlowHeader

--- a/src/pages/onboarding/import-seed.tsx
+++ b/src/pages/onboarding/import-seed.tsx
@@ -197,7 +197,7 @@ const ImportSeed = ({
   }
 
   return (
-    <section className="flex h-full w-full justify-center px-6 py-8">
+    <section className="flex min-h-full w-full justify-center px-6 py-8">
       <div className="flex w-full max-w-sm flex-col justify-between gap-6">
         <div className="space-y-3 text-center">
           <FlowHeader

--- a/src/pages/onboarding/import-vault.tsx
+++ b/src/pages/onboarding/import-vault.tsx
@@ -184,7 +184,7 @@ const ImportVault = () => {
   }
 
   return (
-    <section className="flex h-full w-full justify-center px-6 py-8">
+    <section className="flex min-h-full w-full justify-center px-6 py-8">
       <div className="flex w-full max-w-sm flex-col justify-between gap-6">
         <div className="space-y-3 text-center">
           <FlowHeader

--- a/src/pages/passphrase-auth.tsx
+++ b/src/pages/passphrase-auth.tsx
@@ -109,7 +109,7 @@ const PassphraseAuth = ({
         }
       }}
     >
-      <DrawerContent className="border-none bg-background">
+      <DrawerContent className="max-h-[90vh] border-none bg-background">
         <DrawerHeader className="space-y-2 text-center">
           <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
             <ShieldCheckIcon className="h-6 w-6 shrink-0 text-primary" />
@@ -118,7 +118,7 @@ const PassphraseAuth = ({
           <DrawerDescription>{subtitle ?? t('passphraseAuth.subtitle')}</DrawerDescription>
         </DrawerHeader>
 
-        <div className="space-y-3 px-4 pb-2">
+        <div className="app-scrollbar min-h-0 flex-1 space-y-3 overflow-y-auto px-4 pb-2">
           <PasswordInput
             id="passphrase"
             groupClassName="h-12"
@@ -134,7 +134,7 @@ const PassphraseAuth = ({
           <p className="text-xs text-muted-foreground">{t('passphraseAuth.securityNote')}</p>
         </div>
 
-        <DrawerFooter>
+        <DrawerFooter className="border-t border-border/60 bg-background">
           <Button
             onClick={handleSubmit}
             size="lg"

--- a/src/pages/select-token.tsx
+++ b/src/pages/select-token.tsx
@@ -2,6 +2,7 @@ import { ChevronRightIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { useBalance } from '@qubic-labs/react'
+import PageHeader from '@/components/page-header'
 import {
   type AggregatedAsset,
   aggregateAssets,
@@ -32,9 +33,9 @@ const SelectToken = () => {
 
   return (
     <section className="flex w-full justify-center pt-4">
-      <div className="flex w-full max-w-sm flex-col gap-4 px-4 pb-2">
+      <div className="flex w-full max-w-sm flex-col gap-4 px-4 pb-4">
         <div className="space-y-1">
-          <h2 className="text-lg font-semibold">{t('transfer.title')}</h2>
+          <PageHeader title={t('transfer.title')} onBack={() => navigate('/home')} />
           <p className="text-xs text-muted-foreground">{t('transfer.selectToken.subtitle')}</p>
         </div>
 

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -194,12 +194,12 @@ const Settings = () => {
           }
         }}
       >
-        <DrawerContent>
+        <DrawerContent className="max-h-[90vh] border-none bg-background">
           <DrawerHeader>
             <DrawerTitle>{t('settings.exportVault.drawerTitle')}</DrawerTitle>
             <DrawerDescription>{t('settings.exportVault.drawerDescription')}</DrawerDescription>
           </DrawerHeader>
-          <div className="space-y-2 px-4">
+          <div className="app-scrollbar min-h-0 flex-1 space-y-2 overflow-y-auto px-4 pb-2">
             <Label htmlFor="export-passphrase">{t('settings.exportVault.passphrase')}</Label>
             <Input
               id="export-passphrase"
@@ -217,7 +217,7 @@ const Settings = () => {
             />
             {exportError && <p className="text-xs text-destructive">{exportError}</p>}
           </div>
-          <DrawerFooter>
+          <DrawerFooter className="border-t border-border/60 bg-background">
             <Button onClick={handleExportVault} disabled={exporting || !exportPassphrase.trim()}>
               <CheckIcon className="h-4 w-4" />
               {exporting ? t('settings.exportVault.exporting') : t('settings.exportVault.confirm')}
@@ -228,11 +228,11 @@ const Settings = () => {
 
       {/* Support Drawer */}
       <Drawer open={supportDrawerOpen} onOpenChange={setSupportDrawerOpen}>
-        <DrawerContent>
+        <DrawerContent className="max-h-[90vh] border-none bg-background">
           <DrawerHeader>
             <DrawerTitle>{t('settings.support.title')}</DrawerTitle>
           </DrawerHeader>
-          <div className="space-y-4 px-4 pb-4">
+          <div className="app-scrollbar min-h-0 flex-1 space-y-4 overflow-y-auto px-4 pb-4">
             <div className="rounded-lg border border-yellow-500/40 bg-yellow-500/10 p-3">
               <div className="flex items-center gap-2">
                 <AlertTriangleIcon className="h-5 w-5 shrink-0 text-yellow-500" />
@@ -270,11 +270,11 @@ const Settings = () => {
 
       {/* About Drawer */}
       <Drawer open={aboutDrawerOpen} onOpenChange={setAboutDrawerOpen}>
-        <DrawerContent>
+        <DrawerContent className="max-h-[90vh] border-none bg-background">
           <DrawerHeader>
             <DrawerTitle>{t('settings.about.title')}</DrawerTitle>
           </DrawerHeader>
-          <div className="space-y-3 px-4 pb-4">
+          <div className="app-scrollbar min-h-0 flex-1 space-y-3 overflow-y-auto px-4 pb-4">
             <div className="flex items-center justify-between text-sm">
               <span className="text-muted-foreground">{t('settings.about.extensionName')}</span>
               <span className="font-medium">{t('settings.about.extensionFullName')}</span>

--- a/src/pages/settings/general.tsx
+++ b/src/pages/settings/general.tsx
@@ -1,8 +1,8 @@
 import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { useTheme } from 'next-themes'
-import { ArrowLeftIcon } from 'lucide-react'
 import { Label } from '@/components/ui/label'
+import PageHeader from '@/components/page-header'
 import {
   Select,
   SelectContent,
@@ -19,17 +19,8 @@ const General = () => {
 
   return (
     <section className="flex w-full justify-center pt-4">
-      <div className="flex w-full max-w-sm flex-col gap-6 px-4">
-        <button
-          type="button"
-          onClick={() => navigate('/settings')}
-          className="flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ArrowLeftIcon className="h-4 w-4" />
-          {t('settings.general.back')}
-        </button>
-
-        <h2 className="text-base font-semibold">{t('settings.general.title')}</h2>
+      <div className="flex w-full max-w-sm flex-col gap-6 px-4 pb-4">
+        <PageHeader title={t('settings.general.title')} onBack={() => navigate('/settings')} />
 
         <div className="space-y-3">
           <Label htmlFor="language" className="text-sm text-muted-foreground">

--- a/src/pages/settings/security.tsx
+++ b/src/pages/settings/security.tsx
@@ -199,12 +199,12 @@ const Security = () => {
           }
         }}
       >
-        <DrawerContent>
+        <DrawerContent className="max-h-[90vh] border-none bg-background">
           <DrawerHeader>
             <DrawerTitle>{t('settings.security.changePasswordDrawerTitle')}</DrawerTitle>
             <DrawerDescription>{t('settings.security.changePasswordDrawerDesc')}</DrawerDescription>
           </DrawerHeader>
-          <div className="space-y-3 px-4">
+          <div className="app-scrollbar min-h-0 flex-1 space-y-3 overflow-y-auto px-4 pb-2">
             <div className="space-y-2">
               <Label htmlFor="current-passphrase">{t('settings.security.currentPassphrase')}</Label>
               <Input
@@ -251,7 +251,7 @@ const Security = () => {
               <p className="text-xs text-destructive">{changePasswordError}</p>
             )}
           </div>
-          <DrawerFooter>
+          <DrawerFooter className="border-t border-border/60 bg-background">
             <Button
               onClick={handleChangePassword}
               disabled={

--- a/src/pages/unlock.tsx
+++ b/src/pages/unlock.tsx
@@ -67,7 +67,7 @@ const Unlock = () => {
 
   return (
     <section className="flex min-h-full w-full justify-center">
-      <div className="flex min-h-full w-full max-w-sm flex-col px-4 pb-6 pt-4">
+      <div className="flex min-h-full w-full max-w-sm flex-col px-4 pb-6 pt-6">
         <div className="mt-8 flex flex-col items-center gap-4 text-center">
           <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary/10">
             <ShieldCheckIcon className="h-8 w-8 text-primary" />

--- a/src/pages/welcome.tsx
+++ b/src/pages/welcome.tsx
@@ -12,7 +12,7 @@ const Welcome = () => {
   const isSidePanelView = getExtensionViewKind() === 'sidepanel'
 
   return (
-    <section className="flex h-full flex-col items-center justify-center gap-6 px-6 text-center">
+    <section className="flex min-h-full flex-col items-center justify-center gap-6 px-6 py-6 text-center">
       <div className="flex flex-col items-center gap-3">
         <img
           src={


### PR DESCRIPTION
## Summary
- fix popup overflow in shared overlays and tall drawers so actions stay reachable in constrained extension views
- align popup page layouts across transfer, onboarding, unlock, and related wallet flows for more consistent spacing and navigation
- address the reported dApp `signTransaction(params)` approval clipping issue in popup mode

## Testing
- verify dApp approval flows in popup mode, including long transaction payloads
- verify wallet drawers and dialogs in popup mode
- verify core popup routes such as transfer, onboarding, unlock, and settings