### PR TITLE
fix: remove the new password from import vault flow

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -573,18 +573,14 @@
       },
       "unlockSecure": {
         "title": "Entsperren und sichern",
-        "subtitle": "Lege ein neues Passwort für dieses Gerät fest und gib bei Bedarf das Quell-Passwort ein.",
-        "newPassphrase": "Neues Tresor-Passwort",
-        "sourcePassphrase": "Quell-Tresor-Passwort"
+        "subtitle": "Lege ein Passwort für dieses Gerät fest.",
+        "newPassphrase": "Tresor-Passwort"
       },
       "review": {
         "title": "Import überprüfen",
         "subtitle": "Bestätige die Datei- und Passwort-Details vor dem Import.",
         "vaultFile": "Tresor-Datei",
         "notSelected": "Nicht ausgewählt",
-        "sourcePassphraseProvided": "Angegeben",
-        "sourcePassphraseSame": "Gleich wie neue",
-        "sourcePassphraseLabel": "Quell-Passwort",
         "addMoreLater": "Du kannst später weitere Konten unter Konten verwalten hinzufügen."
       },
       "actions": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -574,13 +574,7 @@
       "unlockSecure": {
         "title": "Entsperren und sichern",
         "subtitle": "Lege ein Passwort für dieses Gerät fest.",
-        "newPassphrase": "Tresor-Passwort"
-      },
-      "review": {
-        "title": "Import überprüfen",
-        "subtitle": "Bestätige die Datei- und Passwort-Details vor dem Import.",
-        "vaultFile": "Tresor-Datei",
-        "notSelected": "Nicht ausgewählt",
+        "newPassphrase": "Tresor-Passwort",
         "addMoreLater": "Du kannst später weitere Konten unter Konten verwalten hinzufügen."
       },
       "actions": {
@@ -593,7 +587,8 @@
         "passphraseRequired": "Passwort ist erforderlich.",
         "importFailed": "Web-Wallet-Tresor konnte nicht importiert werden.",
         "noEntries": "Tresor importiert, aber keine Einträge gefunden.",
-        "generic": "Tresor konnte nicht importiert werden."
+        "generic": "Tresor konnte nicht importiert werden.",
+        "invalidPassphrase": "Ungültiges Passwort. Bitte versuche es erneut."
       }
     },
     "seedSecurity": {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -588,7 +588,7 @@
         "importFailed": "Web-Wallet-Tresor konnte nicht importiert werden.",
         "noEntries": "Tresor importiert, aber keine Einträge gefunden.",
         "generic": "Tresor konnte nicht importiert werden.",
-        "invalidPassphrase": "Ungültiges Passwort. Bitte versuche es erneut."
+        "invalidFileOrPassphrase": "Die ausgewählte Datei ist keine Qubic-Tresor-Datei oder das Passwort ist falsch."
       }
     },
     "seedSecurity": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -588,7 +588,7 @@
         "importFailed": "Failed to import web wallet vault.",
         "noEntries": "Vault imported but no entries were found.",
         "generic": "Failed to import vault.",
-        "invalidPassphrase": "Invalid password. Please try again."
+        "invalidFileOrPassphrase": "Selected file is not a Qubic vault file or password is incorrect."
       }
     },
     "seedSecurity": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -573,18 +573,14 @@
       },
       "unlockSecure": {
         "title": "Unlock and secure",
-        "subtitle": "Provide a new password for this device and, if needed, the source password.",
-        "newPassphrase": "New vault password",
-        "sourcePassphrase": "Source vault password"
+        "subtitle": "Enter the password for this vault file. You'll use the same password to unlock the wallet on this device.",
+        "newPassphrase": "Vault password"
       },
       "review": {
         "title": "Review import",
         "subtitle": "Confirm the file and password details before importing.",
         "vaultFile": "Vault file",
         "notSelected": "Not selected",
-        "sourcePassphraseProvided": "Provided",
-        "sourcePassphraseSame": "Same as new",
-        "sourcePassphraseLabel": "Source password",
         "addMoreLater": "You can add more accounts later in Manage Accounts."
       },
       "actions": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -574,13 +574,7 @@
       "unlockSecure": {
         "title": "Unlock and secure",
         "subtitle": "Enter the password for this vault file. You'll use the same password to unlock the wallet on this device.",
-        "newPassphrase": "Vault password"
-      },
-      "review": {
-        "title": "Review import",
-        "subtitle": "Confirm the file and password details before importing.",
-        "vaultFile": "Vault file",
-        "notSelected": "Not selected",
+        "newPassphrase": "Vault password",
         "addMoreLater": "You can add more accounts later in Manage Accounts."
       },
       "actions": {
@@ -593,7 +587,8 @@
         "passphraseRequired": "Password is required.",
         "importFailed": "Failed to import web wallet vault.",
         "noEntries": "Vault imported but no entries were found.",
-        "generic": "Failed to import vault."
+        "generic": "Failed to import vault.",
+        "invalidPassphrase": "Invalid password. Please try again."
       }
     },
     "seedSecurity": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -588,7 +588,7 @@
         "importFailed": "No se pudo importar el vault de la billetera web.",
         "noEntries": "Vault importado pero no se encontraron entradas.",
         "generic": "No se pudo importar el vault.",
-        "invalidPassphrase": "Contraseña inválida. Intenta de nuevo."
+        "invalidFileOrPassphrase": "El archivo seleccionado no es un archivo Qubic vault o la contraseña es incorrecta."
       }
     },
     "seedSecurity": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -574,13 +574,7 @@
       "unlockSecure": {
         "title": "Desbloquear y asegurar",
         "subtitle": "Ingresa la contraseña de este archivo de vault. Usarás la misma contraseña para desbloquear la billetera en este dispositivo.",
-        "newPassphrase": "Contraseña del vault"
-      },
-      "review": {
-        "title": "Revisar importación",
-        "subtitle": "Confirma los detalles del archivo y la contraseña antes de importar.",
-        "vaultFile": "Archivo vault",
-        "notSelected": "No seleccionado",
+        "newPassphrase": "Contraseña del vault",
         "addMoreLater": "Puedes agregar más cuentas luego en Administrar Cuentas."
       },
       "actions": {
@@ -593,7 +587,8 @@
         "passphraseRequired": "Se requiere contraseña.",
         "importFailed": "No se pudo importar el vault de la billetera web.",
         "noEntries": "Vault importado pero no se encontraron entradas.",
-        "generic": "No se pudo importar el vault."
+        "generic": "No se pudo importar el vault.",
+        "invalidPassphrase": "Contraseña inválida. Intenta de nuevo."
       }
     },
     "seedSecurity": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -573,18 +573,14 @@
       },
       "unlockSecure": {
         "title": "Desbloquear y asegurar",
-        "subtitle": "Proporciona una nueva contraseña para este dispositivo y, si es necesario, la contraseña de origen.",
-        "newPassphrase": "Nueva contraseña del vault",
-        "sourcePassphrase": "Contraseña del vault de origen"
+        "subtitle": "Ingresa la contraseña de este archivo de vault. Usarás la misma contraseña para desbloquear la billetera en este dispositivo.",
+        "newPassphrase": "Contraseña del vault"
       },
       "review": {
         "title": "Revisar importación",
         "subtitle": "Confirma los detalles del archivo y la contraseña antes de importar.",
         "vaultFile": "Archivo vault",
         "notSelected": "No seleccionado",
-        "sourcePassphraseProvided": "Proporcionada",
-        "sourcePassphraseSame": "Igual que la nueva",
-        "sourcePassphraseLabel": "Contraseña de origen",
         "addMoreLater": "Puedes agregar más cuentas luego en Administrar Cuentas."
       },
       "actions": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -573,18 +573,14 @@
       },
       "unlockSecure": {
         "title": "Déverrouiller et sécuriser",
-        "subtitle": "Définissez un nouveau mot de passe pour cet appareil et, si nécessaire, le mot de passe source.",
-        "newPassphrase": "Nouveau mot de passe du vault",
-        "sourcePassphrase": "Mot de passe du vault source"
+        "subtitle": "Définissez un mot de passe pour cet appareil.",
+        "newPassphrase": "Mot de passe du vault"
       },
       "review": {
         "title": "Vérifier l'importation",
         "subtitle": "Confirmez le fichier et les détails du mot de passe avant d'importer.",
         "vaultFile": "Fichier vault",
         "notSelected": "Non sélectionné",
-        "sourcePassphraseProvided": "Fourni",
-        "sourcePassphraseSame": "Identique au nouveau",
-        "sourcePassphraseLabel": "Mot de passe source",
         "addMoreLater": "Vous pourrez ajouter d'autres comptes plus tard dans Gérer les comptes."
       },
       "actions": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -574,13 +574,7 @@
       "unlockSecure": {
         "title": "Déverrouiller et sécuriser",
         "subtitle": "Définissez un mot de passe pour cet appareil.",
-        "newPassphrase": "Mot de passe du vault"
-      },
-      "review": {
-        "title": "Vérifier l'importation",
-        "subtitle": "Confirmez le fichier et les détails du mot de passe avant d'importer.",
-        "vaultFile": "Fichier vault",
-        "notSelected": "Non sélectionné",
+        "newPassphrase": "Mot de passe du vault",
         "addMoreLater": "Vous pourrez ajouter d'autres comptes plus tard dans Gérer les comptes."
       },
       "actions": {
@@ -593,7 +587,8 @@
         "passphraseRequired": "Le mot de passe est requis.",
         "importFailed": "Échec de l'importation du vault du portefeuille web.",
         "noEntries": "Vault importé mais aucune entrée trouvée.",
-        "generic": "Échec de l'importation du vault."
+        "generic": "Échec de l'importation du vault.",
+        "invalidPassphrase": "Mot de passe invalide. Veuillez réessayer."
       }
     },
     "seedSecurity": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -588,7 +588,7 @@
         "importFailed": "Échec de l'importation du vault du portefeuille web.",
         "noEntries": "Vault importé mais aucune entrée trouvée.",
         "generic": "Échec de l'importation du vault.",
-        "invalidPassphrase": "Mot de passe invalide. Veuillez réessayer."
+        "invalidFileOrPassphrase": "Le fichier sélectionné n'est pas un fichier Qubic vault ou le mot de passe est incorrect."
       }
     },
     "seedSecurity": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -588,7 +588,7 @@
         "importFailed": "Не удалось импортировать vault веб-кошелька.",
         "noEntries": "Vault импортирован, но записи не найдены.",
         "generic": "Не удалось импортировать vault.",
-        "invalidPassphrase": "Неверный пароль. Попробуйте снова."
+        "invalidFileOrPassphrase": "Выбранный файл не является файлом Qubic vault или пароль введён неверно."
       }
     },
     "seedSecurity": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -574,13 +574,7 @@
       "unlockSecure": {
         "title": "Разблокировка и защита",
         "subtitle": "Задайте пароль для этого устройства.",
-        "newPassphrase": "Пароль vault"
-      },
-      "review": {
-        "title": "Проверка импорта",
-        "subtitle": "Подтвердите файл и пароль перед импортом.",
-        "vaultFile": "Файл vault",
-        "notSelected": "Не выбран",
+        "newPassphrase": "Пароль vault",
         "addMoreLater": "Вы можете добавить больше аккаунтов позже в разделе Управление аккаунтами."
       },
       "actions": {
@@ -593,7 +587,8 @@
         "passphraseRequired": "Необходимо ввести пароль.",
         "importFailed": "Не удалось импортировать vault веб-кошелька.",
         "noEntries": "Vault импортирован, но записи не найдены.",
-        "generic": "Не удалось импортировать vault."
+        "generic": "Не удалось импортировать vault.",
+        "invalidPassphrase": "Неверный пароль. Попробуйте снова."
       }
     },
     "seedSecurity": {

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -573,18 +573,14 @@
       },
       "unlockSecure": {
         "title": "Разблокировка и защита",
-        "subtitle": "Задайте новый пароль для этого устройства и, при необходимости, пароль исходного vault.",
-        "newPassphrase": "Новый пароль vault",
-        "sourcePassphrase": "Пароль исходного vault"
+        "subtitle": "Задайте пароль для этого устройства.",
+        "newPassphrase": "Пароль vault"
       },
       "review": {
         "title": "Проверка импорта",
         "subtitle": "Подтвердите файл и пароль перед импортом.",
         "vaultFile": "Файл vault",
         "notSelected": "Не выбран",
-        "sourcePassphraseProvided": "Указан",
-        "sourcePassphraseSame": "Совпадает с новым",
-        "sourcePassphraseLabel": "Пароль источника",
         "addMoreLater": "Вы можете добавить больше аккаунтов позже в разделе Управление аккаунтами."
       },
       "actions": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -588,7 +588,7 @@
         "importFailed": "Web cüzdanı vault dosyası içe aktarılamadı.",
         "noEntries": "Vault içe aktarıldı ancak hiçbir giriş bulunamadı.",
         "generic": "Vault içe aktarılamadı.",
-        "invalidPassphrase": "Geçersiz parola. Lütfen tekrar deneyin."
+        "invalidFileOrPassphrase": "Seçilen dosya bir Qubic vault dosyası değil veya parola yanlış."
       }
     },
     "seedSecurity": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -573,18 +573,14 @@
       },
       "unlockSecure": {
         "title": "Kilidi aç ve güvence altına al",
-        "subtitle": "Bu cihaz için yeni bir parola belirleyin ve gerekirse kaynak parolayı girin.",
-        "newPassphrase": "Yeni vault parolası",
-        "sourcePassphrase": "Kaynak vault parolası"
+        "subtitle": "Bu cihaz için bir parola belirleyin.",
+        "newPassphrase": "Vault parolası"
       },
       "review": {
         "title": "İçe aktarmayı gözden geçir",
         "subtitle": "İçe aktarmadan önce dosya ve parola detaylarını doğrulayın.",
         "vaultFile": "Vault dosyası",
         "notSelected": "Seçilmedi",
-        "sourcePassphraseProvided": "Girildi",
-        "sourcePassphraseSame": "Yenisi ile aynı",
-        "sourcePassphraseLabel": "Kaynak parolası",
         "addMoreLater": "Daha sonra Hesapları Yönet bölümünden daha fazla hesap ekleyebilirsiniz."
       },
       "actions": {

--- a/src/locales/tr.json
+++ b/src/locales/tr.json
@@ -574,13 +574,7 @@
       "unlockSecure": {
         "title": "Kilidi aç ve güvence altına al",
         "subtitle": "Bu cihaz için bir parola belirleyin.",
-        "newPassphrase": "Vault parolası"
-      },
-      "review": {
-        "title": "İçe aktarmayı gözden geçir",
-        "subtitle": "İçe aktarmadan önce dosya ve parola detaylarını doğrulayın.",
-        "vaultFile": "Vault dosyası",
-        "notSelected": "Seçilmedi",
+        "newPassphrase": "Vault parolası",
         "addMoreLater": "Daha sonra Hesapları Yönet bölümünden daha fazla hesap ekleyebilirsiniz."
       },
       "actions": {
@@ -593,7 +587,8 @@
         "passphraseRequired": "Parola gereklidir.",
         "importFailed": "Web cüzdanı vault dosyası içe aktarılamadı.",
         "noEntries": "Vault içe aktarıldı ancak hiçbir giriş bulunamadı.",
-        "generic": "Vault içe aktarılamadı."
+        "generic": "Vault içe aktarılamadı.",
+        "invalidPassphrase": "Geçersiz parola. Lütfen tekrar deneyin."
       }
     },
     "seedSecurity": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -573,18 +573,14 @@
       },
       "unlockSecure": {
         "title": "Mở khóa và bảo mật",
-        "subtitle": "Cung cấp mật khẩu mới cho thiết bị này và mật khẩu nguồn nếu cần.",
-        "newPassphrase": "Mật khẩu vault mới",
-        "sourcePassphrase": "Mật khẩu vault nguồn"
+        "subtitle": "Cung cấp mật khẩu cho thiết bị này.",
+        "newPassphrase": "Mật khẩu vault"
       },
       "review": {
         "title": "Xem lại nhập",
         "subtitle": "Xác nhận chi tiết tập tin và mật khẩu trước khi nhập.",
         "vaultFile": "Tập tin vault",
         "notSelected": "Chưa chọn",
-        "sourcePassphraseProvided": "Đã cung cấp",
-        "sourcePassphraseSame": "Giống mật khẩu mới",
-        "sourcePassphraseLabel": "Mật khẩu nguồn",
         "addMoreLater": "Bạn có thể thêm tài khoản sau trong Quản lý tài khoản."
       },
       "actions": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -574,13 +574,7 @@
       "unlockSecure": {
         "title": "Mở khóa và bảo mật",
         "subtitle": "Cung cấp mật khẩu cho thiết bị này.",
-        "newPassphrase": "Mật khẩu vault"
-      },
-      "review": {
-        "title": "Xem lại nhập",
-        "subtitle": "Xác nhận chi tiết tập tin và mật khẩu trước khi nhập.",
-        "vaultFile": "Tập tin vault",
-        "notSelected": "Chưa chọn",
+        "newPassphrase": "Mật khẩu vault",
         "addMoreLater": "Bạn có thể thêm tài khoản sau trong Quản lý tài khoản."
       },
       "actions": {
@@ -593,7 +587,8 @@
         "passphraseRequired": "Yêu cầu mật khẩu.",
         "importFailed": "Không thể nhập vault từ ví web.",
         "noEntries": "Đã nhập vault nhưng không tìm thấy mục nào.",
-        "generic": "Không thể nhập vault."
+        "generic": "Không thể nhập vault.",
+        "invalidPassphrase": "Mật khẩu không hợp lệ. Vui lòng thử lại."
       }
     },
     "seedSecurity": {

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -588,7 +588,7 @@
         "importFailed": "Không thể nhập vault từ ví web.",
         "noEntries": "Đã nhập vault nhưng không tìm thấy mục nào.",
         "generic": "Không thể nhập vault.",
-        "invalidPassphrase": "Mật khẩu không hợp lệ. Vui lòng thử lại."
+        "invalidFileOrPassphrase": "Tập tin đã chọn không phải là tập tin Qubic vault hoặc mật khẩu không chính xác."
       }
     },
     "seedSecurity": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -573,18 +573,14 @@
       },
       "unlockSecure": {
         "title": "解锁并设置安全",
-        "subtitle": "为此设备设置新密码，如需要，请提供来源 vault 密码。",
-        "newPassphrase": "新 vault 密码",
-        "sourcePassphrase": "来源 vault 密码"
+        "subtitle": "为此设备设置密码。",
+        "newPassphrase": "Vault 密码"
       },
       "review": {
         "title": "审核导入",
         "subtitle": "导入前请确认文件和密码信息。",
         "vaultFile": "vault 文件",
         "notSelected": "未选择",
-        "sourcePassphraseProvided": "已提供",
-        "sourcePassphraseSame": "与新密码相同",
-        "sourcePassphraseLabel": "来源密码",
         "addMoreLater": "您可以稍后在「管理账户」中添加更多账户。"
       },
       "actions": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -588,7 +588,7 @@
         "importFailed": "导入网页钱包 vault 失败。",
         "noEntries": "vault 已导入但未找到任何条目。",
         "generic": "导入 vault 失败。",
-        "invalidPassphrase": "密码无效，请重试。"
+        "invalidFileOrPassphrase": "选择的文件不是 Qubic vault 文件，或者密码不正确。"
       }
     },
     "seedSecurity": {

--- a/src/locales/zh.json
+++ b/src/locales/zh.json
@@ -574,13 +574,7 @@
       "unlockSecure": {
         "title": "解锁并设置安全",
         "subtitle": "为此设备设置密码。",
-        "newPassphrase": "Vault 密码"
-      },
-      "review": {
-        "title": "审核导入",
-        "subtitle": "导入前请确认文件和密码信息。",
-        "vaultFile": "vault 文件",
-        "notSelected": "未选择",
+        "newPassphrase": "Vault 密码",
         "addMoreLater": "您可以稍后在「管理账户」中添加更多账户。"
       },
       "actions": {
@@ -593,7 +587,8 @@
         "passphraseRequired": "请输入密码。",
         "importFailed": "导入网页钱包 vault 失败。",
         "noEntries": "vault 已导入但未找到任何条目。",
-        "generic": "导入 vault 失败。"
+        "generic": "导入 vault 失败。",
+        "invalidPassphrase": "密码无效，请重试。"
       }
     },
     "seedSecurity": {

--- a/src/pages/onboarding/import-vault.tsx
+++ b/src/pages/onboarding/import-vault.tsx
@@ -22,7 +22,6 @@ const ImportVault = () => {
   const [step, setStep] = useState(1)
   const [file, setFile] = useState<File | null>(null)
   const [passphrase, setPassphrase] = useState('')
-  const [sourcePassphrase, setSourcePassphrase] = useState('')
   const [status, setStatus] = useState<string | null>(null)
   const [isSaving, setIsSaving] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
@@ -30,7 +29,6 @@ const ImportVault = () => {
 
   const clearSensitiveState = () => {
     setPassphrase('')
-    setSourcePassphrase('')
     setFile(null)
   }
 
@@ -106,9 +104,8 @@ const ImportVault = () => {
 
       if (isWebWalletVault) {
         const qubicVault = new QubicVault()
-        const importPassphrase = sourcePassphrase.trim() || passphrase.trim()
 
-        const success = await qubicVault.importAndUnlock(true, importPassphrase, null, file, false)
+        const success = await qubicVault.importAndUnlock(true, passphrase.trim(), null, file, false)
         if (!success) {
           setStatus(t('onboarding.importVault.errors.importFailed'))
           setIsSaving(false)
@@ -160,7 +157,7 @@ const ImportVault = () => {
         const vault = await openBrowserVault(passphrase.trim(), true)
         await vault.importEncrypted(fileText, {
           mode: 'merge',
-          sourcePassphrase: sourcePassphrase.trim() || passphrase.trim(),
+          sourcePassphrase: passphrase.trim(),
         })
         await vault.save()
         saveCachedAccounts(vault.list().map((e) => ({ name: e.name, identity: e.identity })))
@@ -266,16 +263,6 @@ const ImportVault = () => {
                   onChange={(event) => setPassphrase(event.target.value)}
                 />
               </div>
-              <div className="space-y-2">
-                <Label htmlFor="source-passphrase">
-                  {t('onboarding.importVault.unlockSecure.sourcePassphrase')}
-                </Label>
-                <PasswordInput
-                  id="source-passphrase"
-                  value={sourcePassphrase}
-                  onChange={(event) => setSourcePassphrase(event.target.value)}
-                />
-              </div>
             </div>
           )}
 
@@ -295,12 +282,6 @@ const ImportVault = () => {
                   <span className="text-foreground">
                     {file?.name ?? t('onboarding.importVault.review.notSelected')}
                   </span>
-                </div>
-                <div className="text-xs text-muted-foreground">
-                  {t('onboarding.importVault.review.sourcePassphraseLabel')}:{' '}
-                  {sourcePassphrase.trim()
-                    ? t('onboarding.importVault.review.sourcePassphraseProvided')
-                    : t('onboarding.importVault.review.sourcePassphraseSame')}
                 </div>
               </div>
               <p className="text-xs text-muted-foreground">

--- a/src/pages/onboarding/import-vault.tsx
+++ b/src/pages/onboarding/import-vault.tsx
@@ -13,7 +13,7 @@ import { QubicVault } from '@qubic-lib/qubic-ts-vault-library/dist/vault.js'
 import { getWatchOnlyAccounts, saveCachedAccounts, saveWatchOnlyAccounts } from '@/lib/accounts'
 import FlowHeader from '@/components/onboarding/flow-header'
 
-const TOTAL_STEPS = 3
+const TOTAL_STEPS = 2
 const MAX_VAULT_FILE_SIZE = 102_400
 
 const ImportVault = () => {
@@ -37,11 +37,6 @@ const ImportVault = () => {
 
     if (step === 1 && !file) {
       setStatus(t('onboarding.importVault.errors.selectFile'))
-      return
-    }
-
-    if (step === 2 && !passphrase.trim()) {
-      setStatus(t('onboarding.importVault.errors.passphraseRequired'))
       return
     }
 
@@ -105,9 +100,21 @@ const ImportVault = () => {
       if (isWebWalletVault) {
         const qubicVault = new QubicVault()
 
-        const success = await qubicVault.importAndUnlock(true, passphrase.trim(), null, file, false)
-        if (!success) {
-          setStatus(t('onboarding.importVault.errors.importFailed'))
+        let unlockSucceeded = false
+        try {
+          unlockSucceeded = await qubicVault.importAndUnlock(
+            true,
+            passphrase.trim(),
+            null,
+            file,
+            false,
+          )
+        } catch {
+          // SDK rejects with a string on wrong password — fall through to the check below
+        }
+        if (!unlockSucceeded) {
+          setStatus(t('onboarding.importVault.errors.invalidPassphrase'))
+          setStep(2)
           setIsSaving(false)
           return
         }
@@ -155,10 +162,17 @@ const ImportVault = () => {
         navigate('/home')
       } else {
         const vault = await openBrowserVault(passphrase.trim(), true)
-        await vault.importEncrypted(fileText, {
-          mode: 'merge',
-          sourcePassphrase: passphrase.trim(),
-        })
+        try {
+          await vault.importEncrypted(fileText, {
+            mode: 'merge',
+            sourcePassphrase: passphrase.trim(),
+          })
+        } catch {
+          setStatus(t('onboarding.importVault.errors.invalidPassphrase'))
+          setStep(2)
+          setIsSaving(false)
+          return
+        }
         await vault.save()
         saveCachedAccounts(vault.list().map((e) => ({ name: e.name, identity: e.identity })))
 
@@ -263,29 +277,8 @@ const ImportVault = () => {
                   onChange={(event) => setPassphrase(event.target.value)}
                 />
               </div>
-            </div>
-          )}
-
-          {step === 3 && (
-            <div className="space-y-4">
-              <div className="space-y-1">
-                <h3 className="text-sm font-semibold">
-                  {t('onboarding.importVault.review.title')}
-                </h3>
-                <p className="text-xs text-muted-foreground">
-                  {t('onboarding.importVault.review.subtitle')}
-                </p>
-              </div>
-              <div className="space-y-2 text-sm">
-                <div className="flex items-center justify-between text-xs text-muted-foreground">
-                  <span>{t('onboarding.importVault.review.vaultFile')}</span>
-                  <span className="text-foreground">
-                    {file?.name ?? t('onboarding.importVault.review.notSelected')}
-                  </span>
-                </div>
-              </div>
               <p className="text-xs text-muted-foreground">
-                {t('onboarding.importVault.review.addMoreLater')}
+                {t('onboarding.importVault.unlockSecure.addMoreLater')}
               </p>
             </div>
           )}

--- a/src/pages/onboarding/import-vault.tsx
+++ b/src/pages/onboarding/import-vault.tsx
@@ -113,7 +113,7 @@ const ImportVault = () => {
           // SDK rejects with a string on wrong password — fall through to the check below
         }
         if (!unlockSucceeded) {
-          setStatus(t('onboarding.importVault.errors.invalidPassphrase'))
+          setStatus(t('onboarding.importVault.errors.invalidFileOrPassphrase'))
           setStep(2)
           setIsSaving(false)
           return
@@ -168,7 +168,7 @@ const ImportVault = () => {
             sourcePassphrase: passphrase.trim(),
           })
         } catch {
-          setStatus(t('onboarding.importVault.errors.invalidPassphrase'))
+          setStatus(t('onboarding.importVault.errors.invalidFileOrPassphrase'))
           setStep(2)
           setIsSaving(false)
           return


### PR DESCRIPTION
- Simplify import-vault flow to a single password (matches mobile): the field decrypts the file and secures the extension vault in one step.
- Drop the third-redundant review step (its only purpose was confirming the dual-password choice) and surface a "you can add more accounts later" hint on the password screen.
- Replace the generic "Failed to import vault" message with a clear actionable error matching mobile ("Selected file is not a Qubic vault file or password is incorrect") and return the user to the password step on failure.