### PR TITLE
fix(ui): use PasswordInput for all password fields

### DIFF
--- a/src/components/pages/manage-accounts/passphrase-prompt-drawer.tsx
+++ b/src/components/pages/manage-accounts/passphrase-prompt-drawer.tsx
@@ -8,7 +8,7 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from '@/components/ui/drawer'
-import { Input } from '@/components/ui/input'
+import { PasswordInput } from '@/components/ui/password-input'
 import { Label } from '@/components/ui/label'
 
 type PassphrasePromptDrawerProps = {
@@ -38,9 +38,8 @@ const PassphrasePromptDrawer = ({
         </DrawerHeader>
         <div className="space-y-2 px-4">
           <Label htmlFor="vault-passphrase">{t('accounts.manage.passphrase')}</Label>
-          <Input
+          <PasswordInput
             id="vault-passphrase"
-            type="password"
             value={passphrase}
             onChange={(event) => onPassphraseChange(event.target.value)}
           />

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -26,7 +26,7 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from '@/components/ui/drawer'
-import { Input } from '@/components/ui/input'
+import { PasswordInput } from '@/components/ui/password-input'
 import { Label } from '@/components/ui/label'
 import { lockWallet } from '@/lib/lock'
 import { openBrowserVault } from '@/lib/vault'
@@ -209,9 +209,8 @@ const Settings = () => {
           </DrawerHeader>
           <div className="app-scrollbar min-h-0 flex-1 space-y-2 overflow-y-auto px-4 pb-2">
             <Label htmlFor="export-passphrase">{t('settings.exportVault.passphrase')}</Label>
-            <Input
+            <PasswordInput
               id="export-passphrase"
-              type="password"
               value={exportPassphrase}
               onChange={(event) => {
                 setExportPassphrase(event.target.value)

--- a/src/pages/settings/security.tsx
+++ b/src/pages/settings/security.tsx
@@ -22,7 +22,7 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from '@/components/ui/drawer'
-import { Input } from '@/components/ui/input'
+import { PasswordInput } from '@/components/ui/password-input'
 import { Label } from '@/components/ui/label'
 import {
   Select,
@@ -207,9 +207,8 @@ const Security = () => {
           <div className="app-scrollbar min-h-0 flex-1 space-y-3 overflow-y-auto px-4 pb-2">
             <div className="space-y-2">
               <Label htmlFor="current-passphrase">{t('settings.security.currentPassphrase')}</Label>
-              <Input
+              <PasswordInput
                 id="current-passphrase"
-                type="password"
                 value={currentPassphrase}
                 onChange={(event) => {
                   setCurrentPassphrase(event.target.value)
@@ -219,9 +218,8 @@ const Security = () => {
             </div>
             <div className="space-y-2">
               <Label htmlFor="new-passphrase">{t('settings.security.newPassphrase')}</Label>
-              <Input
+              <PasswordInput
                 id="new-passphrase"
-                type="password"
                 value={newPassphrase}
                 onChange={(event) => {
                   setNewPassphrase(event.target.value)
@@ -232,9 +230,8 @@ const Security = () => {
             </div>
             <div className="space-y-2">
               <Label htmlFor="confirm-passphrase">{t('settings.security.confirmPassphrase')}</Label>
-              <Input
+              <PasswordInput
                 id="confirm-passphrase"
-                type="password"
                 value={confirmPassphrase}
                 onChange={(event) => {
                   setConfirmPassphrase(event.target.value)


### PR DESCRIPTION
Replace raw <Input type="password"> with the shared PasswordInput component so users get the show/hide eye toggle in: Change password (current/new/confirm), Export vault, and the manage-accounts passphrase prompt. Brings these flows in line with Unlock, Onboarding, Import seed, Import vault, and dApp approval.

Closes #160