### PR TITLE
feat(dapp): submit approval on Enter key in passphrase input

### DIFF
--- a/src/components/dapp/dapp-approval-drawer.tsx
+++ b/src/components/dapp/dapp-approval-drawer.tsx
@@ -406,6 +406,11 @@ const DappApprovalDrawer = () => {
                   setPassphrase(event.target.value)
                   if (error) setError('')
                 }}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter' && !loading) {
+                    void submitDecision(true)
+                  }
+                }}
                 className="h-12 text-base"
               />
             )}


### PR DESCRIPTION
Adds an onKeyDown handler on the dApp approval drawer's passphrase input so pressing Enter approves the request, matching the existing unlock screen pattern and removing the need to scroll/click on small or low-DPI displays.