### PR TITLE
fix: clear sensitive state on lock and flag IDN origins

### DIFF
--- a/src/components/dapp/dapp-approval-drawer.tsx
+++ b/src/components/dapp/dapp-approval-drawer.tsx
@@ -35,6 +35,7 @@ import {
 import AddressLabel from '@/components/address-label'
 import { useTxTypeDescription } from '@/hooks/use-tx-type-description'
 import { isWalletLocked } from '@/lib/lock'
+import IdnWarningBadge from '@/components/idn-warning-badge'
 import { validateVaultPassphrase } from '@/lib/vault'
 import { toast } from 'sonner'
 
@@ -72,7 +73,9 @@ const DappApprovalDrawer = () => {
 
   useEffect(() => {
     const syncLockState = () => {
-      setLocked(isWalletLocked())
+      const nowLocked = isWalletLocked()
+      if (nowLocked) setPassphrase('')
+      setLocked(nowLocked)
     }
 
     syncLockState()
@@ -286,6 +289,7 @@ const DappApprovalDrawer = () => {
                 {t('dapp.approval.origin')}
               </p>
               <p className="truncate text-sm font-medium text-foreground">{current.origin}</p>
+              <IdnWarningBadge origin={current.origin} />
             </div>
             {current.method === 'connect' && connectSummary && (
               <div className="rounded-xl border border-border/60 bg-background/40 p-3">

--- a/src/components/idn-warning-badge.tsx
+++ b/src/components/idn-warning-badge.tsx
@@ -1,0 +1,18 @@
+import { TriangleAlertIcon } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { hasIdnHostname } from '@/lib/utils'
+
+type Props = { origin: string }
+
+const IdnWarningBadge = ({ origin }: Props) => {
+  const { t } = useTranslation()
+  if (!hasIdnHostname(origin)) return null
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full border border-amber-500/50 bg-amber-500/10 px-2 py-0.5 text-[11px] font-medium text-amber-600 dark:text-amber-400">
+      <TriangleAlertIcon className="h-3 w-3" />
+      {t('dapp.idnWarning')}
+    </span>
+  )
+}
+
+export default IdnWarningBadge

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -149,6 +149,15 @@ export const formatAddressLabel = (
   return `${name} (${truncated})`
 }
 
+export const hasIdnHostname = (origin: string): boolean => {
+  try {
+    const { hostname } = new URL(origin)
+    return hostname.includes('xn--') || /[^\x00-\x7F]/.test(hostname)
+  } catch {
+    return false
+  }
+}
+
 export type ExplorerObject = 'tx'
 
 export const compareBigIntDesc = (a: string, b: string): number => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -152,7 +152,7 @@ export const formatAddressLabel = (
 export const hasIdnHostname = (origin: string): boolean => {
   try {
     const { hostname } = new URL(origin)
-    return hostname.includes('xn--') || /[^\x00-\x7F]/.test(hostname)
+    return hostname.includes('xn--') || /[^a-z0-9.-]/i.test(hostname)
   } catch {
     return false
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -471,6 +471,7 @@
     "importVault": "Import vault backup"
   },
   "dapp": {
+    "idnWarning": "Internationalized domain",
     "approval": {
       "title": "Connection request",
       "connectTitle": "Connection request",

--- a/src/pages/manage-accounts.tsx
+++ b/src/pages/manage-accounts.tsx
@@ -22,6 +22,7 @@ import {
   repairDuplicateVaultEntries,
   setOnboarded,
 } from '@/lib/vault'
+import { isWalletLocked } from '@/lib/lock'
 import AccountListItem from '@/components/pages/manage-accounts/account-list-item'
 import AddAccountDrawer from '@/components/pages/manage-accounts/add-account-drawer'
 import RenameAccountDrawer from '@/components/pages/manage-accounts/rename-account-drawer'
@@ -125,6 +126,19 @@ const ManageAccounts = () => {
       window.removeEventListener('wallet-account-updated', handleStorage)
     }
   }, [refreshFromCache])
+
+  useEffect(() => {
+    const onLock = () => {
+      if (!isWalletLocked()) return
+      setRevealedSeed('')
+      setSeedTarget(null)
+      setPassphraseInput('')
+      setPassphrasePromptOpen(false)
+      setPendingAction(null)
+    }
+    window.addEventListener('wallet-lock-updated', onLock)
+    return () => window.removeEventListener('wallet-lock-updated', onLock)
+  }, [])
 
   const balanceQueries = useQueries({
     queries: orderedAccounts.map((account) => ({

--- a/src/pages/onboarding/create-wallet.tsx
+++ b/src/pages/onboarding/create-wallet.tsx
@@ -6,7 +6,7 @@ import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { generateSeed, isSeedLike } from '@/lib/seed'
 import { validatePassphraseStrength } from '@/lib/passphrase'
-import { setUnlocked } from '@/lib/lock'
+import { isWalletLocked, setUnlocked } from '@/lib/lock'
 import {
   openBrowserVault,
   setOnboarded,
@@ -62,6 +62,18 @@ const CreateWallet = ({
     setConfirmPassphrase('')
     setHasConfirmedSeedBackup(false)
   }
+
+  useEffect(() => {
+    const onLock = () => {
+      if (!isWalletLocked()) return
+      setSeed('')
+      setPassphrase('')
+      setConfirmPassphrase('')
+      setHasConfirmedSeedBackup(false)
+    }
+    window.addEventListener('wallet-lock-updated', onLock)
+    return () => window.removeEventListener('wallet-lock-updated', onLock)
+  }, [])
 
   useEffect(() => {
     let isActive = true

--- a/src/pages/onboarding/import-seed.tsx
+++ b/src/pages/onboarding/import-seed.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { identityFromSeed } from '@qubic-labs/core'
 import { ArrowLeftIcon, ArrowRightIcon, KeyRoundIcon } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
@@ -16,7 +16,7 @@ import {
   isAccountNameTaken,
   saveCachedAccounts,
 } from '@/lib/accounts'
-import { setUnlocked } from '@/lib/lock'
+import { isWalletLocked, setUnlocked } from '@/lib/lock'
 import {
   openBrowserVault,
   setOnboarded,
@@ -72,6 +72,17 @@ const ImportSeed = ({
     setPassphrase('')
     setDerivedIdentity(null)
   }
+
+  useEffect(() => {
+    const onLock = () => {
+      if (!isWalletLocked()) return
+      setSeed('')
+      setPassphrase('')
+      setDerivedIdentity(null)
+    }
+    window.addEventListener('wallet-lock-updated', onLock)
+    return () => window.removeEventListener('wallet-lock-updated', onLock)
+  }, [])
 
   const handleSeedChange = (value: string) => {
     setSeed(normalizeSeedInput(value))

--- a/src/pages/settings/connected-sites.tsx
+++ b/src/pages/settings/connected-sites.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/lib/dapp/storage'
 import { useAccountNames } from '@/hooks/use-account-names'
 import { truncateString } from '@/lib/utils'
+import IdnWarningBadge from '@/components/idn-warning-badge'
 
 const ConnectedSites = () => {
   const { t } = useTranslation()
@@ -87,6 +88,7 @@ const ConnectedSites = () => {
                 <div className="flex items-start gap-3">
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm font-medium text-foreground">{site.origin}</p>
+                    <IdnWarningBadge origin={site.origin} />
                     <p className="mt-1 text-xs text-muted-foreground">
                       {t('settings.connectedSites.connectedAt', {
                         date: new Date(site.connectedAt).toLocaleString(),


### PR DESCRIPTION
## Summary

- On wallet lock, immediately zero `revealedSeed`, `passphraseInput`, and
  close the reveal-seed and passphrase-prompt drawers in `manage-accounts.tsx`.
  `dapp-approval-drawer.tsx` already tracked lock state; it now also clears
  `passphrase` in the same effect.
- Added `hasIdnHostname` utility that detects `xn--` punycode or non-ASCII
  characters in a parsed hostname. A shared `IdnWarningBadge` component renders
  an amber pill below the origin in the dApp approval drawer and the
  connected-sites settings page.

## Test plan

- [ ] Open the reveal-seed drawer, wait for (or trigger) auto-lock — drawer
      closes and seed is cleared before the `/unlock` redirect
- [ ] Open the dApp approval popup with a signing request, trigger lock —
      passphrase field clears and drawer closes
- [ ] Existing lock → redirect to `/unlock` flow still works normally
- [ ] Load a dApp approval request from an `xn--` origin — amber
      "Internationalized domain" badge appears below the origin
- [ ] Same badge appears on the connected-sites page for any IDN origin
- [ ] ASCII-only origins show no badge